### PR TITLE
Ignore dlv debugger file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.osm.bz2
 *.pbf
+
+# ignore dlv debugger file
+**/debug.test


### PR DESCRIPTION
When using the dlv debugger for test debugging, a 'debug.test' file is written. Those files should be git ignored.
