### PR TITLE
Do not allocate individual nodes and ways. Try to optimize tags.

### DIFF
--- a/osmpbf/decode_tag.go
+++ b/osmpbf/decode_tag.go
@@ -7,12 +7,12 @@ func extractTags(stringTable []string, keyIDs, valueIDs []uint32) osm.Tags {
 		return nil
 	}
 
-	tags := make(osm.Tags, 0, len(keyIDs))
+	tags := make(osm.Tags, len(keyIDs))
 	for index, keyID := range keyIDs {
-		tags = append(tags, osm.Tag{
+		tags[index] = osm.Tag{
 			Key:   stringTable[keyID],
 			Value: stringTable[valueIDs[index]],
-		})
+		}
 	}
 
 	return tags


### PR DESCRIPTION
Hi, this patch does 

```benchmark             old ns/op     new ns/op     delta
BenchmarkDecode-8     391812006     371380236     -5.21%
BenchmarkLondon-8     404719571     372010852     -8.08%

benchmark             old allocs     new allocs     delta
BenchmarkDecode-8     7732810        4545134        -41.22%
BenchmarkLondon-8     7732810        4545136        -41.22%

benchmark             old bytes      new bytes      delta
BenchmarkDecode-8     1306695317     1305444093     -0.10%
BenchmarkLondon-8     1306695613     1305443602     -0.10%
```

for me with go 1.14.x .

But times are varying a lot. When doing benchmarking, previous to this change I can see a lot of lock contention for struct allocating and scaling for large core counts will not help at all, quite the contrary in fact. At least this pressure is a somehow diminished by this patch.
Optimizing relations does not help anything. Regarding tags I am not sure why it did make a difference, but it did at some point. We can leave it out. 

Overall, without breaking the API design I see no more improvements regarding scaling of memory allocation.