### PR TITLE
support node locations in relation members

### DIFF
--- a/osmgeojson/build_polygon.go
+++ b/osmgeojson/build_polygon.go
@@ -34,8 +34,15 @@ func (ctx *context) buildPolygon(relation *osm.Relation) *geojson.Feature {
 
 		way := ctx.wayMap[osm.WayID(m.Ref)]
 		if way == nil {
-			tainted = true
-			continue
+			if len(m.Nodes) != 0 {
+				way = &osm.Way{
+					ID:    osm.WayID(m.Ref),
+					Nodes: m.Nodes,
+				}
+			} else {
+				tainted = true
+				continue
+			}
 		}
 
 		if m.Role == "outer" {

--- a/osmgeojson/convert_test.go
+++ b/osmgeojson/convert_test.go
@@ -95,6 +95,48 @@ func TestConvert(t *testing.T) {
 		testConvert(t, xml, fc)
 	})
 
+	t.Run("relation with nodes in members", func(t *testing.T) {
+		xml := `
+		<osm>
+			<relation id='1'>
+				<tag k='type' v='multipolygon' />
+				<tag k="admin_level" v="8"/>
+				<tag k="boundary" v="administrative"/>
+				<member type='way' ref='2' role='outer'>
+					<nd lat='-1.0' lon='-1.0' />
+					<nd lat='-1.0' lon='1.0' />
+					<nd lat='1.0' lon='1.0' />
+					<nd lat='1.0' lon='-1.0' />
+					<nd lat='-1.0' lon='-1.0' />
+				</member>
+				<member type='way' ref='3' role='inner'>
+					<nd lat='-0.5' lon='0.0' />
+					<nd lat='0.5' lon='0.0' />
+					<nd lat='0.0' lon='0.5' />
+					<nd lat='-0.5' lon='0.0' />
+				</member>
+			</relation>
+		</osm>`
+
+		polygon := orb.Polygon{
+			{{-1, -1}, {1, -1}, {1, 1}, {-1, 1}, {-1, -1}},
+			{{0, -0.5}, {0, 0.5}, {0.5, 0}, {0, -0.5}},
+		}
+
+		feature := geojson.NewFeature(polygon)
+		feature.ID = "relation/1"
+		feature.Properties["type"] = "relation"
+		feature.Properties["id"] = 1
+		feature.Properties["tags"] = map[string]string{
+			"admin_level": "8",
+			"boundary":    "administrative",
+			"type":        "multipolygon",
+		}
+
+		fc := geojson.NewFeatureCollection().Append(feature)
+		testConvert(t, xml, fc)
+	})
+
 	t.Run("relation", func(t *testing.T) {
 		xml := `
 		<osm>

--- a/relation.go
+++ b/relation.go
@@ -76,6 +76,10 @@ type Member struct {
 	// Orientation is the direction of the way around a ring of a multipolygon.
 	// Only valid for multipolygon or boundary relations.
 	Orientation orb.Orientation `xml:"orienation,attr,omitempty" json:"orienation,omitempty"`
+
+	// Nodes are sometimes included in members of type way to include the lat/lon
+	// path of the way. Overpass returns xml like this.
+	Nodes WayNodes `xml:"nd" json:"nodes,omitempty"`
 }
 
 // ObjectID returns the object id of the relation.

--- a/relation_test.go
+++ b/relation_test.go
@@ -167,6 +167,17 @@ func TestRelation_MarshalXML(t *testing.T) {
 		t.Errorf("not marshalled correctly: %s", string(data))
 	}
 
+	// members with nodes
+	r.Members = Members{{Type: "way", Ref: 123, Role: "child", Nodes: WayNodes{{Lat: 1, Lon: 2}, {Lat: 3, Lon: 4}}}}
+	data, err = xml.Marshal(r)
+	if err != nil {
+		t.Fatalf("xml marshal error: %v", err)
+	}
+
+	if !bytes.Equal(data, []byte(`<relation id="123" user="" uid="0" visible="false" version="0" changeset="0" timestamp="0001-01-01T00:00:00Z"><member type="way" ref="123" role="child"><nd lat="1" lon="2"></nd><nd lat="3" lon="4"></nd></member></relation>`)) {
+		t.Errorf("not marshalled correctly: %s", string(data))
+	}
+
 	// minor relation
 	r.Members = nil
 	r.Updates = []Update{

--- a/way.go
+++ b/way.go
@@ -59,7 +59,7 @@ type WayNodes []WayNode
 
 // WayNode is a short node used as part of ways and relations in the osm xml.
 type WayNode struct {
-	ID NodeID `xml:"ref,attr"`
+	ID NodeID `xml:"ref,attr,omitempty"`
 
 	// These attributes are populated for concrete versions of ways.
 	Version     int         `xml:"version,attr,omitempty"`

--- a/way_test.go
+++ b/way_test.go
@@ -253,13 +253,13 @@ func TestWay_MarshalXML(t *testing.T) {
 	}
 
 	// node with lat/lon
-	w.Nodes[0] = WayNode{Lat: 1, Lon: 2}
+	w.Nodes[0] = WayNode{ID: 4, Lat: 1, Lon: 2}
 	data, err = xml.Marshal(w)
 	if err != nil {
 		t.Fatalf("xml marshal error: %v", err)
 	}
 
-	if !bytes.Equal(data, []byte(`<way id="123" user="" uid="0" visible="false" version="0" changeset="0" timestamp="0001-01-01T00:00:00Z"><nd ref="0" lat="1" lon="2"></nd></way>`)) {
+	if !bytes.Equal(data, []byte(`<way id="123" user="" uid="0" visible="false" version="0" changeset="0" timestamp="0001-01-01T00:00:00Z"><nd ref="4" lat="1" lon="2"></nd></way>`)) {
 		t.Errorf("not marshalled correctly: %s", string(data))
 	}
 


### PR DESCRIPTION
Fixes https://github.com/paulmach/osm/issues/11

Overpass generates XML with the node locations inside a way member like
```
  <relation id="146656">
    <bounds minlat="53.3401044" minlon="-2.3199185" maxlat="53.5445923" maxlon="-2.1468288"/>
    <member type="way" ref="651749181" role="outer">
      <nd lat="53.4224846" lon="-2.2736200"/>
      <nd lat="53.4225401" lon="-2.2737196"/>
      ...
    </member>
    <tag k="ISO3166-2" v="GB-MAN"/>
    <tag k="admin_level" v="8"/>
    <tag k="boundary" v="administrative"/>
</relation>
```

This PR adds XML Unmarshalling support and osmgeojson knows that locations can be found in this location too.