### PR TITLE
osmpbf: use cgo/czlib for decompressions, with build tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/paulmach/osm
 go 1.13
 
 require (
+	github.com/datadog/czlib v0.0.0-20160811164712-4bc9a24e37f2
 	github.com/gogo/protobuf v1.3.1
 	github.com/paulmach/orb v0.1.6
 	github.com/paulmach/protoscan v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/datadog/czlib v0.0.0-20160811164712-4bc9a24e37f2 h1:ISaMhBq2dagaoptFGUyywT5SzpysCbHofX3sCNw1djo=
+github.com/datadog/czlib v0.0.0-20160811164712-4bc9a24e37f2/go.mod h1:2yDaWzisHKoQoxm+EU4YgKBaD7g1M0pxy7THWG44Lro=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/gogo/protobuf v1.3.0 h1:G8O7TerXerS4F6sx9OV7/nRfJdnXgHZu/S/7F2SN+UE=
@@ -22,6 +24,7 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -54,6 +57,7 @@ golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -70,6 +74,7 @@ google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miE
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
+google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/osmpbf/decode.go
+++ b/osmpbf/decode.go
@@ -2,7 +2,6 @@ package osmpbf
 
 import (
 	"bytes"
-	"compress/zlib"
 	"context"
 	"encoding/binary"
 	"errors"
@@ -342,7 +341,7 @@ func getData(blob *osmpbf.Blob, data []byte) ([]byte, error) {
 		return blob.GetRaw(), nil
 
 	case blob.ZlibData != nil:
-		r, err := zlib.NewReader(bytes.NewReader(blob.GetZlibData()))
+		r, err := zlibReader(blob.GetZlibData())
 		if err != nil {
 			return nil, err
 		}

--- a/osmpbf/zlib_cgo.go
+++ b/osmpbf/zlib_cgo.go
@@ -1,0 +1,14 @@
+// +build cgo
+
+package osmpbf
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/datadog/czlib"
+)
+
+func zlibReader(data []byte) (io.ReadCloser, error) {
+	return czlib.NewReader(bytes.NewReader(data))
+}

--- a/osmpbf/zlib_go.go
+++ b/osmpbf/zlib_go.go
@@ -1,0 +1,13 @@
+// +build !cgo
+
+package osmpbf
+
+import (
+	"bytes"
+	"compress/zlib"
+	"io"
+)
+
+func zlibReader(data []byte) (io.ReadCloser, error) {
+	return zlib.NewReader(bytes.NewReader(data))
+}


### PR DESCRIPTION
The pbf data comes in blocks, each block is zlib compressed. Decompressing this data takes about 33% of the total read time on my benchmarks. I added support for a cgo version, https://github.com/DataDog/czlib with a build tag.

```
> CGO_ENABLED=0 go test -bench . 
BenchmarkLondon-12             3         341655178 ns/op        1245167664 B/op  4544349 allocs/op

> CGO_ENABLED=1 go test -bench . 
BenchmarkLondon-12             4         266967016 ns/op        1236313254 B/op  4492042 allocs/op

> benchcmp
benchmark              old ns/op     new ns/op     delta
BenchmarkLondon-12     341655178     266967016     -21.86%

benchmark              old allocs     new allocs     delta
BenchmarkLondon-12     4544349        4492042        -1.15%

benchmark              old bytes      new bytes      delta
BenchmarkLondon-12     1245167664     1236313254     -0.71%
```

The performance benefit is pretty large but I'm not sure what the community thinking around cgo is, so leaving this hear for now. I'm hoping the build tag support will make it usable.