### PR TITLE
Typos and redundant parenthesis

### DIFF
--- a/osmpbf/decode_data.go
+++ b/osmpbf/decode_data.go
@@ -382,7 +382,7 @@ func (dec *dataDecoder) extractDenseNodes() error {
 			return err
 		}
 		lat += v8
-		n.Lat = 1e-9 * float64((latOffset + (granularity * lat)))
+		n.Lat = 1e-9 * float64(latOffset + (granularity * lat))
 
 		// lon
 		v9, err := dec.lons.Sint64()
@@ -390,7 +390,7 @@ func (dec *dataDecoder) extractDenseNodes() error {
 			return err
 		}
 		lon += v9
-		n.Lon = 1e-9 * float64((lonOffset + (granularity * lon)))
+		n.Lon = 1e-9 * float64(lonOffset + (granularity * lon))
 
 		// tags, could be missing if all nodes are tagless
 		if dec.keyvals != nil {

--- a/relation.go
+++ b/relation.go
@@ -75,7 +75,7 @@ type Member struct {
 
 	// Orientation is the direction of the way around a ring of a multipolygon.
 	// Only valid for multipolygon or boundary relations.
-	Orientation orb.Orientation `xml:"orienation,attr,omitempty" json:"orienation,omitempty"`
+	Orientation orb.Orientation `xml:"orientation,attr,omitempty" json:"orientation,omitempty"`
 
 	// Nodes are sometimes included in members of type way to include the lat/lon
 	// path of the way. Overpass returns xml like this.

--- a/relation.go
+++ b/relation.go
@@ -19,7 +19,7 @@ func (id RelationID) ObjectID(v int) ObjectID {
 
 // FeatureID is a helper returning the feature id for this relation id.
 func (id RelationID) FeatureID() FeatureID {
-	return FeatureID((relationMask | id<<versionBits))
+	return FeatureID(relationMask | id<<versionBits)
 }
 
 // ElementID is a helper to convert the id to an element id.

--- a/replication/changesets.go
+++ b/replication/changesets.go
@@ -162,5 +162,5 @@ func (ds *Datasource) changesetURL(n ChangesetSeqNum) string {
 		ds.baseURL(),
 		n/1000000,
 		(n%1000000)/1000,
-		(n % 1000))
+		n % 1000)
 }

--- a/replication/interval.go
+++ b/replication/interval.go
@@ -343,5 +343,5 @@ func (ds *Datasource) baseSeqURL(sn SeqNum) string {
 		sn.Dir(),
 		n/1000000,
 		(n%1000000)/1000,
-		(n % 1000))
+		n % 1000)
 }

--- a/update.go
+++ b/update.go
@@ -49,7 +49,7 @@ func (us Updates) UpTo(t time.Time) Updates {
 	return result
 }
 
-// UpdateIndexOutOfRangeError is return when appling an update to an object
+// UpdateIndexOutOfRangeError is return when applying an update to an object
 // and the update index is out of range.
 type UpdateIndexOutOfRangeError struct {
 	Index int


### PR DESCRIPTION
Hey @paulmach,

I ran in IntelliJ `Code → Inspect Code...` and hopefully improved the code by applying some suggestions from the inspection result.

I could remove f6de7e8 if the change of the structs tag break compatibility. `go clean -testcache && go test $(go list ./...)` suceeded.

Best regards
Marcel