### PR TITLE
osmpbf: do not preallocate nodes

### DIFF
--- a/osmpbf/decode_data.go
+++ b/osmpbf/decode_data.go
@@ -309,17 +309,12 @@ func (dec *dataDecoder) extractDenseNodes() error {
 	latOffset := dec.primitiveBlock.GetLatOffset()
 	lonOffset := dec.primitiveBlock.GetLonOffset()
 
-	// we also assume all the iterators have the same length....
-
-	nodes := make([]osm.Node, dec.versions.Count(protoscan.WireTypeVarint))
-
 	var id, lat, lon, timestamp, changeset int64
 	var uid, usid int32
-	var index int
 	for dec.versions.HasNext() {
-		n := &nodes[index]
-		n.Visible = true
-		index++
+		// NOTE: do not try pre-allocating an array of nodes because saving
+		// just one will stop the GC from cleaning up the whole pre-allocated array.
+		n := &osm.Node{Visible: true}
 
 		// ID
 		v1, err := dec.ids.Sint64()


### PR DESCRIPTION
regarding https://github.com/paulmach/osm/issues/25 on high memory usage.

I noticed that pre-allocating the nodes could cause problems if you're saving some of them for later use. If just 1 node out of the whole 8000 node array is saved, the GC can not cleanup the any of them. 

Benchmarks are impacted:
```
benchmark                        old ns/op     new ns/op     delta
BenchmarkLondon-12               235836166     248139745     +5.22%
BenchmarkLondon_nodes-12         163988036     177138150     +8.02%
BenchmarkLondon_ways-12          136805230     135422092     -1.01%
BenchmarkLondon_relations-12     82180166      81767765      -0.50%

benchmark                        old allocs     new allocs     delta
BenchmarkLondon-12               2416813        5145479        +112.90%
BenchmarkLondon_nodes-12         1003846        3732512        +271.82%
BenchmarkLondon_ways-12          1792714        1792718        +0.00%
BenchmarkLondon_relations-12     456772         456772         +0.00%

benchmark                        old bytes     new bytes     delta
BenchmarkLondon-12               954879689     952781068     -0.22%
BenchmarkLondon_nodes-12         649480586     647382889     -0.32%
BenchmarkLondon_ways-12          432818482     432819399     +0.00%
BenchmarkLondon_relations-12     179085842     179085459     -0.00%
```