### PR TITLE
osmpbf: add filter functions

### DIFF
--- a/osmpbf/README.md
+++ b/osmpbf/README.md
@@ -1,5 +1,4 @@
-osm/osmpbf [![Go Reference](https://pkg.go.dev/badge/github.com/paulmach/osm.svg)](https://pkg.go.dev/github.com/paulmach/osm/osmpbf)
-==========
+# osm/osmpbf [![Go Reference](https://pkg.go.dev/badge/github.com/paulmach/osm.svg)](https://pkg.go.dev/github.com/paulmach/osm/osmpbf)
 
 Package osmpbf provides a scanner for decoding large [OSM PBF](https://wiki.openstreetmap.org/wiki/PBF_Format) files.
 They are typically found at [planet.osm.org](https://planet.openstreetmap.org/) or [Geofabrik Download](https://download.geofabrik.de/).
@@ -48,6 +47,28 @@ type Scanner struct {
 	SkipNodes     bool
 	SkipWays      bool
 	SkipRelations bool
+
+	// contains filtered or unexported fields
+}
+```
+
+### Filtering Elements
+
+The above skips all elements of a type. To filter based on the element's tags or
+other values, use the filter functions. These filter functions are called in parallel
+and not in a predefined order. If that is okay, they can be more performant than
+the "scanner" api.
+
+```
+type Scanner struct {
+	// If the Filter function is false, the element well be skipped
+	// at the decoding level. The functions should be fast, they block the
+	// decoder, there are `procs` number of concurrent decoders.
+	// Elements can be stored if the function returns true. Memory is
+	// reused if the filter returns false.
+	FilterNode     func(*osm.Node) bool
+	FilterWay      func(*osm.Way) bool
+	FilterRelation func(*osm.Relation) bool
 
 	// contains filtered or unexported fields
 }

--- a/osmpbf/README.md
+++ b/osmpbf/README.md
@@ -3,7 +3,7 @@
 Package osmpbf provides a scanner for decoding large [OSM PBF](https://wiki.openstreetmap.org/wiki/PBF_Format) files.
 They are typically found at [planet.osm.org](https://planet.openstreetmap.org/) or [Geofabrik Download](https://download.geofabrik.de/).
 
-### Example:
+## Example:
 
 ```go
 file, err := os.Open("./delaware-latest.osm.pbf")
@@ -33,7 +33,7 @@ if err := scanner.Err(); err != nil {
 **Note:** Scanners are **not** safe for parallel use. One should feed the
 objects into a channel and have workers read from that.
 
-### Skipping Types
+## Skipping Types
 
 Sometimes only ways or relations are needed. In this case reading and creating
 those objects can be skipped completely. After creating the Scanner set the appropriate
@@ -52,12 +52,12 @@ type Scanner struct {
 }
 ```
 
-### Filtering Elements
+## Filtering Elements
 
 The above skips all elements of a type. To filter based on the element's tags or
 other values, use the filter functions. These filter functions are called in parallel
-and not in a predefined order. If that is okay, they can be more performant than
-the "scanner" api.
+and not in a predefined order. This can be a performant way to filter for elements
+with a certain set of tags.
 
 ```
 type Scanner struct {
@@ -74,7 +74,7 @@ type Scanner struct {
 }
 ```
 
-### OSM PBF files with node locations on ways
+## OSM PBF files with node locations on ways
 
 This package supports reading OSM PBF files where the ways have been annotated with the coordinates of each node. Such files can be generated using [osmium](https://osmcode.org/osmium-tool), with the [add-locations-to-ways](https://docs.osmcode.org/osmium/latest/osmium-add-locations-to-ways.html) subcommand. This feature makes it possible to work with the ways and their geometries without having to keep all node locations in some index (which takes work and memory resources).
 

--- a/osmpbf/decode_data.go
+++ b/osmpbf/decode_data.go
@@ -147,6 +147,9 @@ func (dec *dataDecoder) scanPrimitiveBlock(data []byte) error {
 func (dec *dataDecoder) scanPrimitiveGroup(data []byte) error {
 	msg := protoscan.New(data)
 
+	way := &osm.Way{Visible: true}
+	relation := &osm.Relation{Visible: true}
+
 	for msg.Next() {
 		fn := msg.FieldNumber()
 		if fn == 1 {
@@ -173,9 +176,18 @@ func (dec *dataDecoder) scanPrimitiveGroup(data []byte) error {
 				return err
 			}
 
-			err = dec.scanWays(data)
+			way, err = dec.scanWays(data, way)
 			if err != nil {
 				return err
+			}
+
+			if dec.scanner.FilterWay == nil || dec.scanner.FilterWay(way) {
+				dec.q = append(dec.q, way)
+				way = &osm.Way{Visible: true}
+			} else {
+				tags := way.Tags
+				nodes := way.Nodes
+				*way = osm.Way{Visible: true, Nodes: nodes[:0], Tags: tags[:0]}
 			}
 
 			continue
@@ -187,9 +199,18 @@ func (dec *dataDecoder) scanPrimitiveGroup(data []byte) error {
 				return err
 			}
 
-			err = dec.scanRelations(data)
+			relation, err = dec.scanRelations(data, relation)
 			if err != nil {
 				return err
+			}
+
+			if dec.scanner.FilterRelation == nil || dec.scanner.FilterRelation(relation) {
+				dec.q = append(dec.q, relation)
+				relation = &osm.Relation{Visible: true}
+			} else {
+				tags := relation.Tags
+				members := relation.Members
+				*relation = osm.Relation{Visible: true, Members: members[:0], Tags: tags[:0]}
 			}
 
 			continue
@@ -465,28 +486,21 @@ func (dec *dataDecoder) extractDenseNodes() error {
 				n.Tags = append(n.Tags, osm.Tag{Key: st[k], Value: st[v]})
 			}
 		}
-		if dec.scanner.NodeFilter == nil || dec.scanner.NodeFilter(*n) {
+
+		if dec.scanner.FilterNode == nil || dec.scanner.FilterNode(n) {
+			dec.q = append(dec.q, n)
+			n = &osm.Node{Visible: true}
+		} else {
 			// skip unwanted nodes
-			index++
-		}
-	}
-	if len(nodes) != index {
-		/* copy to an array just large enough */
-		tmp := make([]osm.Node, index)
-		copy(tmp, nodes)
-		for i := range tmp {
-			dec.q = append(dec.q, &tmp[i])
-		}
-	} else {
-		for i := range nodes {
-			dec.q = append(dec.q, &nodes[i])
+			tags := n.Tags
+			*n = osm.Node{Visible: true, Tags: tags[:0]}
 		}
 	}
 
 	return nil
 }
 
-func (dec *dataDecoder) scanWays(data []byte) error {
+func (dec *dataDecoder) scanWays(data []byte, way *osm.Way) (*osm.Way, error) {
 	st := dec.primitiveBlock.GetStringtable().GetS()
 	granularity := int64(dec.primitiveBlock.GetGranularity())
 	dateGranularity := int64(dec.primitiveBlock.GetDateGranularity())
@@ -496,7 +510,10 @@ func (dec *dataDecoder) scanWays(data []byte) error {
 
 	msg := protoscan.New(data)
 
-	way := &osm.Way{Visible: true}
+	if way == nil {
+		way = &osm.Way{Visible: true}
+	}
+
 	var foundKeys, foundVals bool
 	for msg.Next() {
 		var i64 int64
@@ -515,7 +532,7 @@ func (dec *dataDecoder) scanWays(data []byte) error {
 		case 4: // info
 			d, err := msg.MessageData()
 			if err != nil {
-				return err
+				return nil, err
 			}
 
 			info := protoscan.New(d)
@@ -524,38 +541,38 @@ func (dec *dataDecoder) scanWays(data []byte) error {
 				case 1:
 					v, err := info.Int32()
 					if err != nil {
-						return err
+						return nil, err
 					}
 					way.Version = int(v)
 				case 2:
 					v, err := info.Int64()
 					if err != nil {
-						return err
+						return nil, err
 					}
 					millisec := time.Duration(v*dateGranularity) * time.Millisecond
 					way.Timestamp = time.Unix(0, millisec.Nanoseconds()).UTC()
 				case 3:
 					v, err := info.Int64()
 					if err != nil {
-						return err
+						return nil, err
 					}
 					way.ChangesetID = osm.ChangesetID(v)
 				case 4:
 					v, err := info.Int32()
 					if err != nil {
-						return err
+						return nil, err
 					}
 					way.UserID = osm.UserID(v)
 				case 5:
 					v, err := info.Uint32()
 					if err != nil {
-						return err
+						return nil, err
 					}
 					way.User = st[v]
 				case 6:
 					v, err := info.Bool()
 					if err != nil {
-						return err
+						return nil, err
 					}
 					way.Visible = v
 				default:
@@ -564,12 +581,12 @@ func (dec *dataDecoder) scanWays(data []byte) error {
 			}
 
 			if info.Err() != nil {
-				return info.Err()
+				return nil, info.Err()
 			}
 		case 8: // refs or nodes
 			dec.nodes, err = msg.Iterator(dec.nodes)
 			if err != nil {
-				return err
+				return nil, err
 			}
 
 			var prev, index int64
@@ -579,7 +596,7 @@ func (dec *dataDecoder) scanWays(data []byte) error {
 			for dec.nodes.HasNext() {
 				v, err := dec.nodes.Sint64()
 				if err != nil {
-					return err
+					return nil, err
 				}
 				prev = v + prev // delta encoding
 				way.Nodes[index].ID = osm.NodeID(prev)
@@ -588,7 +605,7 @@ func (dec *dataDecoder) scanWays(data []byte) error {
 		case 9: // lat
 			dec.wlats, err = msg.Iterator(dec.wlats)
 			if err != nil {
-				return err
+				return nil, err
 			}
 
 			var prev, index int64
@@ -598,7 +615,7 @@ func (dec *dataDecoder) scanWays(data []byte) error {
 			for dec.wlats.HasNext() {
 				v, err := dec.wlats.Sint64()
 				if err != nil {
-					return err
+					return nil, err
 				}
 				prev = v + prev // delta encoding
 				way.Nodes[index].Lat = 1e-9 * float64(latOffset+(granularity*prev))
@@ -607,7 +624,7 @@ func (dec *dataDecoder) scanWays(data []byte) error {
 		case 10: // lon
 			dec.wlons, err = msg.Iterator(dec.wlons)
 			if err != nil {
-				return err
+				return nil, err
 			}
 
 			var prev, index int64
@@ -617,7 +634,7 @@ func (dec *dataDecoder) scanWays(data []byte) error {
 			for dec.wlons.HasNext() {
 				v, err := dec.wlons.Sint64()
 				if err != nil {
-					return err
+					return nil, err
 				}
 				prev = v + prev // delta encoding
 				way.Nodes[index].Lon = 1e-9 * float64(lonOffset+(granularity*prev))
@@ -628,25 +645,23 @@ func (dec *dataDecoder) scanWays(data []byte) error {
 		}
 
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
 	if msg.Err() != nil {
-		return msg.Err()
+		return nil, msg.Err()
 	}
 
 	if foundKeys && foundVals {
 		var err error
 		way.Tags, err = scanTags(st, dec.keys, dec.vals)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
-	if dec.scanner.WayFilter == nil || dec.scanner.WayFilter(*way) {
-		dec.q = append(dec.q, way)
-	}
-	return nil
+
+	return way, nil
 }
 
 // Make relation members from stringtable and three parallel arrays of IDs.
@@ -693,13 +708,16 @@ func extractMembers(
 	return members, nil
 }
 
-func (dec *dataDecoder) scanRelations(data []byte) error {
+func (dec *dataDecoder) scanRelations(data []byte, relation *osm.Relation) (*osm.Relation, error) {
 	st := dec.primitiveBlock.GetStringtable().GetS()
 	dateGranularity := int64(dec.primitiveBlock.GetDateGranularity())
 
 	msg := protoscan.New(data)
 
-	relation := &osm.Relation{Visible: true}
+	if relation == nil {
+		relation = &osm.Relation{Visible: true}
+	}
+
 	var foundKeys, foundVals, foundRoles, foundMemids, foundTypes bool
 	for msg.Next() {
 		var i64 int64
@@ -718,7 +736,7 @@ func (dec *dataDecoder) scanRelations(data []byte) error {
 		case 4: // info
 			d, err := msg.MessageData()
 			if err != nil {
-				return err
+				return nil, err
 			}
 
 			info := protoscan.New(d)
@@ -727,38 +745,38 @@ func (dec *dataDecoder) scanRelations(data []byte) error {
 				case 1:
 					v, err := info.Int32()
 					if err != nil {
-						return err
+						return nil, err
 					}
 					relation.Version = int(v)
 				case 2:
 					v, err := info.Int64()
 					if err != nil {
-						return err
+						return nil, err
 					}
 					millisec := time.Duration(v*dateGranularity) * time.Millisecond
 					relation.Timestamp = time.Unix(0, millisec.Nanoseconds()).UTC()
 				case 3:
 					v, err := info.Int64()
 					if err != nil {
-						return err
+						return nil, err
 					}
 					relation.ChangesetID = osm.ChangesetID(v)
 				case 4:
 					v, err := info.Int32()
 					if err != nil {
-						return err
+						return nil, err
 					}
 					relation.UserID = osm.UserID(v)
 				case 5:
 					v, err := info.Uint32()
 					if err != nil {
-						return err
+						return nil, err
 					}
 					relation.User = st[v]
 				case 6:
 					v, err := info.Bool()
 					if err != nil {
-						return err
+						return nil, err
 					}
 					relation.Visible = v
 				default:
@@ -767,7 +785,7 @@ func (dec *dataDecoder) scanRelations(data []byte) error {
 			}
 
 			if info.Err() != nil {
-				return info.Err()
+				return nil, info.Err()
 			}
 		case 8: // refs or nodes
 			dec.roles, err = msg.Iterator(dec.roles)
@@ -783,12 +801,12 @@ func (dec *dataDecoder) scanRelations(data []byte) error {
 		}
 
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
 	if msg.Err() != nil {
-		return msg.Err()
+		return nil, msg.Err()
 	}
 
 	// possible for relation to not have tags
@@ -796,7 +814,7 @@ func (dec *dataDecoder) scanRelations(data []byte) error {
 		var err error
 		relation.Tags, err = scanTags(st, dec.keys, dec.vals)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
@@ -805,13 +823,11 @@ func (dec *dataDecoder) scanRelations(data []byte) error {
 		var err error
 		relation.Members, err = extractMembers(st, dec.roles, dec.memids, dec.types)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
-	if dec.scanner.RelationFilter == nil || dec.scanner.RelationFilter(*relation) {
-		dec.q = append(dec.q, relation)
-	}
-	return nil
+
+	return relation, nil
 }
 
 func scanTags(stringTable []string, keys, vals *protoscan.Iterator) (osm.Tags, error) {

--- a/osmpbf/decode_data.go
+++ b/osmpbf/decode_data.go
@@ -465,8 +465,22 @@ func (dec *dataDecoder) extractDenseNodes() error {
 				n.Tags = append(n.Tags, osm.Tag{Key: st[k], Value: st[v]})
 			}
 		}
-
-		dec.q = append(dec.q, n)
+		if dec.scanner.NodeFilter == nil || dec.scanner.NodeFilter(*n) {
+			// skip unwanted nodes
+			index++
+		}
+	}
+	if len(nodes) != index {
+		/* copy to an array just large enough */
+		tmp := make([]osm.Node, index)
+		copy(tmp, nodes)
+		for i := range tmp {
+			dec.q = append(dec.q, &tmp[i])
+		}
+	} else {
+		for i := range nodes {
+			dec.q = append(dec.q, &nodes[i])
+		}
 	}
 
 	return nil
@@ -629,8 +643,9 @@ func (dec *dataDecoder) scanWays(data []byte) error {
 			return err
 		}
 	}
-
-	dec.q = append(dec.q, way)
+	if dec.scanner.WayFilter == nil || dec.scanner.WayFilter(*way) {
+		dec.q = append(dec.q, way)
+	}
 	return nil
 }
 
@@ -793,8 +808,9 @@ func (dec *dataDecoder) scanRelations(data []byte) error {
 			return err
 		}
 	}
-
-	dec.q = append(dec.q, relation)
+	if dec.scanner.RelationFilter == nil || dec.scanner.RelationFilter(*relation) {
+		dec.q = append(dec.q, relation)
+	}
 	return nil
 }
 

--- a/osmpbf/scanner.go
+++ b/osmpbf/scanner.go
@@ -23,9 +23,12 @@ type Scanner struct {
 	// Skip element types that are not needed. The data is skipped
 	// at the encoded protobuf level, but each block still
 	// needs to be decompressed.
-	SkipNodes     bool
-	SkipWays      bool
-	SkipRelations bool
+	SkipNodes      bool
+	SkipWays       bool
+	SkipRelations  bool
+	NodeFilter     func(osm.Node) bool
+	WayFilter      func(osm.Way) bool
+	RelationFilter func(osm.Relation) bool
 
 	ctx    context.Context
 	closed bool

--- a/osmpbf/scanner.go
+++ b/osmpbf/scanner.go
@@ -21,14 +21,17 @@ var _ osm.Scanner = &Scanner{}
 // https://golang.org/pkg/bufio/#Scanner
 type Scanner struct {
 	// Skip element types that are not needed. The data is skipped
-	// at the encoded protobuf level, but each block still
-	// needs to be decompressed.
-	SkipNodes      bool
-	SkipWays       bool
-	SkipRelations  bool
-	NodeFilter     func(osm.Node) bool
-	WayFilter      func(osm.Way) bool
-	RelationFilter func(osm.Relation) bool
+	// at the encoded protobuf level, but each block still needs to be decompressed.
+	SkipNodes     bool
+	SkipWays      bool
+	SkipRelations bool
+
+	// If the Filter function is false, the element well be skipped
+	// at the decoding level. The functions should be fast, they block the
+	// decoder, there are `procs` number of concurrent decoders.
+	FilterNode     func(*osm.Node) bool
+	FilterWay      func(*osm.Way) bool
+	FilterRelation func(*osm.Relation) bool
 
 	ctx    context.Context
 	closed bool

--- a/osmpbf/scanner.go
+++ b/osmpbf/scanner.go
@@ -29,6 +29,8 @@ type Scanner struct {
 	// If the Filter function is false, the element well be skipped
 	// at the decoding level. The functions should be fast, they block the
 	// decoder, there are `procs` number of concurrent decoders.
+	// Elements can be stored if the function returns true. Memory is
+	// reused if the filter returns false.
 	FilterNode     func(*osm.Node) bool
 	FilterWay      func(*osm.Way) bool
 	FilterRelation func(*osm.Relation) bool


### PR DESCRIPTION
This is the completion of https://github.com/paulmach/osm/pull/27

Adds filter functions
```
type Scanner struct {
	// If the Filter function is false, the element well be skipped
	// at the decoding level. The functions should be fast, they block the
	// decoder, there are `procs` number of concurrent decoders.
	// Elements can be stored if the function returns true. Memory is
	// reused if the filter returns false.
	FilterNode     func(*osm.Node) bool
	FilterWay      func(*osm.Way) bool
	FilterRelation func(*osm.Relation) bool

	// contains filtered or unexported fields
}
```

@oflebbe