### PR TITLE
replication: ability to get changeset state

### DIFF
--- a/replication/changesets.go
+++ b/replication/changesets.go
@@ -42,12 +42,12 @@ func CurrentChangesetState(ctx context.Context) (ChangesetSeqNum, *State, error)
 // CurrentChangesetState returns the current state of the changeset replication.
 func (ds *Datasource) CurrentChangesetState(ctx context.Context) (ChangesetSeqNum, *State, error) {
 	url := ds.baseURL() + "/replication/changesets/state.yaml"
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return 0, nil, err
 	}
 
-	resp, err := ds.client().Do(req.WithContext(ctx))
+	resp, err := ds.client().Do(req)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -162,5 +162,5 @@ func (ds *Datasource) changesetURL(n ChangesetSeqNum) string {
 		ds.baseURL(),
 		n/1000000,
 		(n%1000000)/1000,
-		n % 1000)
+		n%1000)
 }

--- a/replication/changesets.go
+++ b/replication/changesets.go
@@ -15,7 +15,7 @@ import (
 )
 
 // ChangesetSeqNum indicates the sequence of the changeset replication found here:
-// http://planet.osm.org/replication/changesets/
+// https://planet.osm.org/replication/changesets/
 type ChangesetSeqNum uint64
 
 // String returns 'changeset/%d'.
@@ -41,20 +41,46 @@ func CurrentChangesetState(ctx context.Context) (ChangesetSeqNum, *State, error)
 
 // CurrentChangesetState returns the current state of the changeset replication.
 func (ds *Datasource) CurrentChangesetState(ctx context.Context) (ChangesetSeqNum, *State, error) {
-	url := ds.baseURL() + "/replication/changesets/state.yaml"
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	s, err := ds.fetchChangesetState(ctx, 0)
 	if err != nil {
 		return 0, nil, err
+	}
+
+	return ChangesetSeqNum(s.SeqNum), s, err
+}
+
+// ChangesetState returns the state for the given changeset replication.
+// Delegates to the DefaultDatasource and uses its http.Client to make the request.
+func ChangesetState(ctx context.Context, n ChangesetSeqNum) (*State, error) {
+	return DefaultDatasource.ChangesetState(ctx, n)
+}
+
+// ChangesetState returns the state for the given changeset replication.
+func (ds *Datasource) ChangesetState(ctx context.Context, n ChangesetSeqNum) (*State, error) {
+	return ds.fetchChangesetState(ctx, n)
+}
+
+func (ds *Datasource) fetchChangesetState(ctx context.Context, n ChangesetSeqNum) (*State, error) {
+	var url string
+	if n.Uint64() != 0 {
+		url = ds.baseChangesetURL(n) + ".state.txt"
+	} else {
+		url = fmt.Sprintf("%s/replication/%s/state.yaml", ds.baseURL(), n.Dir())
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
 	}
 
 	resp, err := ds.client().Do(req)
 	if err != nil {
-		return 0, nil, err
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		return 0, nil, &UnexpectedStatusCodeError{
+		return nil, &UnexpectedStatusCodeError{
 			Code: resp.StatusCode,
 			URL:  url,
 		}
@@ -62,11 +88,25 @@ func (ds *Datasource) CurrentChangesetState(ctx context.Context) (ChangesetSeqNu
 
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return 0, nil, err
+		return nil, err
 	}
 
 	s, err := decodeChangesetState(data)
-	return ChangesetSeqNum(s.SeqNum), s, err
+	if err != nil {
+		return nil, err
+	}
+
+	// starting at 2008004 the changeset sequence number in the state file is
+	// one less than the name of the file. This is a consistent mistake.
+	// The correctly paired state and data files have the same name. The number
+	// in the state file is the one that is off.
+	if n == 0 {
+		s.SeqNum++
+	} else {
+		s.SeqNum = uint64(n)
+	}
+
+	return s, nil
 }
 
 func decodeChangesetState(data []byte) (*State, error) {
@@ -160,6 +200,16 @@ func (ds *Datasource) changesetReader(ctx context.Context, n ChangesetSeqNum) (i
 func (ds *Datasource) changesetURL(n ChangesetSeqNum) string {
 	return fmt.Sprintf("%s/replication/changesets/%03d/%03d/%03d.osm.gz",
 		ds.baseURL(),
+		n/1000000,
+		(n%1000000)/1000,
+		n%1000)
+}
+
+func (ds *Datasource) baseChangesetURL(cn ChangesetSeqNum) string {
+	n := cn.Uint64()
+	return fmt.Sprintf("%s/replication/%s/%03d/%03d/%03d",
+		ds.baseURL(),
+		cn.Dir(),
 		n/1000000,
 		(n%1000000)/1000,
 		n%1000)

--- a/replication/changesets_test.go
+++ b/replication/changesets_test.go
@@ -1,6 +1,9 @@
 package replication
 
 import (
+	"bytes"
+	"compress/gzip"
+	"context"
 	"testing"
 	"time"
 )
@@ -22,5 +25,45 @@ sequence: 1912325
 
 	if err != nil {
 		t.Errorf("got error: %v", err)
+	}
+}
+
+func TestChangesetDecoder(t *testing.T) {
+	ctx := context.Background()
+
+	buf := bytes.NewBuffer(nil)
+	w := gzip.NewWriter(buf)
+	w.Write([]byte(`
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="replicate_changesets.rb">
+  <changeset id="41976776" created_at="2016-09-07T11:11:04Z" closed_at="2016-09-07T11:11:19Z" open="false" num_changes="3" user="ابو عمار ياسر" uid="4537049" min_lat="15.3098203" max_lat="15.3316814" min_lon="44.2181132" max_lon="44.2335361" comments_count="0">
+    <tag k="created_by" v="MAPS.ME android 6.3.7-Google"/>
+    <tag k="comment" v="Created a clinic, a government office, and a supermarket shop"/>
+    <tag k="bundle_id" v="com.mapswithme.maps.pro"/>
+  </changeset>
+  <changeset id="41976777" created_at="2016-09-07T11:11:17Z" closed_at="2016-09-07T11:11:18Z" open="false" num_changes="45" user="blubber75" uid="4522866" min_lat="49.7560493" max_lat="49.756761" min_lon="8.6103231" max_lon="8.6120139" comments_count="0">
+    <tag k="comment" v="gebäude"/>
+    <tag k="locale" v="de"/>
+    <tag k="host" v="https://www.openstreetmap.org/id"/>
+    <tag k="imagery_used" v="Bing"/>
+    <tag k="created_by" v="iD 1.9.7"/>
+  </changeset>
+</osm>`))
+	w.Close()
+
+	changesets, err := changesetDecoder(ctx, buf)
+	if err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+
+	if len(changesets) != 2 {
+		t.Errorf("incorrect number of changes: %d", len(changesets))
+	}
+}
+
+func TestBaseChangesetURL(t *testing.T) {
+	url := DefaultDatasource.baseChangesetURL(123456789)
+	if url != "https://planet.osm.org/replication/changesets/123/456/789" {
+		t.Errorf("incorrect url, got %v", url)
 	}
 }

--- a/replication/datasource.go
+++ b/replication/datasource.go
@@ -6,8 +6,8 @@ import (
 	"time"
 )
 
-// BaseURL defines the planet server to hit.
-const BaseURL = "http://planet.osm.org"
+// BaseURL defines the default planet server to hit.
+const BaseURL = "https://planet.osm.org"
 
 // Datasource defines context around replication data requests.
 type Datasource struct {
@@ -63,6 +63,10 @@ func (e *UnexpectedStatusCodeError) Error() string {
 // NotFound will return try if the error from one of the methods was due
 // to the file not found on the remote host.
 func NotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+
 	if e, ok := err.(*UnexpectedStatusCodeError); ok {
 		return e.Code == http.StatusNotFound
 	}

--- a/replication/datasource.go
+++ b/replication/datasource.go
@@ -60,6 +60,16 @@ func (e *UnexpectedStatusCodeError) Error() string {
 	return fmt.Sprintf("replication: unexpected status code of %d for url %s", e.Code, e.URL)
 }
 
+// NotFound will return try if the error from one of the methods was due
+// to the file not found on the remote host.
+func NotFound(err error) bool {
+	if e, ok := err.(*UnexpectedStatusCodeError); ok {
+		return e.Code == http.StatusNotFound
+	}
+
+	return false
+}
+
 // timeFormats contains the set of different formats we've see the time in.
 var timeFormats = []string{
 	"2006-01-02 15:04:05.999999999 Z",

--- a/replication/interval_test.go
+++ b/replication/interval_test.go
@@ -35,14 +35,4 @@ txnActiveList=836441203
 	if err != nil {
 		t.Errorf("got error: %v", err)
 	}
-
-	// to do some live testing
-	// ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	// defer cancel()
-
-	// log.Println(CurrentMinuteState(ctx))
-	// log.Println(MinuteState(ctx, 2139244))
-	// log.Println(CurrentHourState(ctx))
-	// log.Println(CurrentDayState(ctx))
-	// log.Println(Minute(ctx, 2010617))
 }

--- a/replication/live_test.go
+++ b/replication/live_test.go
@@ -75,3 +75,34 @@ func TestChangesets(t *testing.T) {
 		t.Errorf("incorrect number of changesets: %v", l)
 	}
 }
+
+func TestChangesetState(t *testing.T) {
+	liveOnly(t)
+
+	ctx := context.Background()
+	state, err := ChangesetState(ctx, 5001990)
+	if err != nil {
+		t.Fatalf("request error: %v", err)
+	}
+
+	if state.SeqNum != 5001990 {
+		t.Errorf("incorrect state: %+v", state)
+	}
+
+	// current state
+	n, state, err := CurrentChangesetState(ctx)
+	if err != nil {
+		t.Fatalf("request error: %v", err)
+	}
+
+	changes, err := Changesets(ctx, n)
+	if err != nil {
+		t.Fatalf("request error: %v", err)
+	}
+
+	for _, c := range changes {
+		if c.CreatedAt.After(state.Timestamp) {
+			t.Errorf("data is after the state file?")
+		}
+	}
+}


### PR DESCRIPTION
Adds a `ChangesetState(ctx context.Context, n ChangesetSeqNum) (*State, error)` function. Also makes sure error message are consistent to more easily detect not-found errors.