### PR TITLE
replication: search for state/sequence number by timestamp

### DIFF
--- a/replication/README.md
+++ b/replication/README.md
@@ -1,5 +1,4 @@
-osm/replication [![Godoc Reference](https://godoc.org/github.com/paulmach/osm/replication?status.svg)](https://godoc.org/github.com/paulmach/osm/replication)
-===============
+# osm/replication [![Godoc Reference](https://pkg.go.dev/badge/github.com/paulmach/osm)](https://pkg.go.dev/github.com/paulmach/osm/replication)
 
 Package `replication` handles fetching the Minute, Hour, Day and Changeset replication
 and the associated state value from [Planet OSM](http://planet.osm.org).
@@ -17,4 +16,16 @@ Once you know the change number you want, fetch the change using:
 
 ```go
 change, err := replication.Minute(ctx, num)
+```
+
+## Finding sequences numbers by timestamp
+
+It's also possible to find the sequence number by timestamp.
+These calls make multiple requests for state to find the one matching the given timestamp.
+
+```go
+MinuteStateAt(ctx context.Context, timestamp time.Time) (MinuteSeqNum, *State, error)
+HourStateAt(ctx context.Context, timestamp time.Time) (HourSeqNum, *State, error)
+DayStateAt(ctx context.Context, timestamp time.Time) (DaySeqNum, *State, error)
+ChangesetStateAt(ctx context.Context, timestamp time.Time) (ChangesetSeqNum, *State, error)
 ```

--- a/replication/changesets.go
+++ b/replication/changesets.go
@@ -50,12 +50,14 @@ func (ds *Datasource) CurrentChangesetState(ctx context.Context) (ChangesetSeqNu
 }
 
 // ChangesetState returns the state for the given changeset replication.
+// There are no state files before 2007990. In that case a 404 error is returned.
 // Delegates to the DefaultDatasource and uses its http.Client to make the request.
 func ChangesetState(ctx context.Context, n ChangesetSeqNum) (*State, error) {
 	return DefaultDatasource.ChangesetState(ctx, n)
 }
 
 // ChangesetState returns the state for the given changeset replication.
+// There are no state files before 2007990. In that case a 404 error is returned.
 func (ds *Datasource) ChangesetState(ctx context.Context, n ChangesetSeqNum) (*State, error) {
 	return ds.fetchChangesetState(ctx, n)
 }

--- a/replication/search.go
+++ b/replication/search.go
@@ -1,0 +1,315 @@
+package replication
+
+import (
+	"context"
+	"time"
+)
+
+// the valid minimum state number on planet.osm.org
+const (
+	minMinute = 1 // up to 2012-09-12T08:15:45Z
+	minHour   = 1 // up to 2013-07-14T12:00:00Z
+	minDay    = 1 // up to 2012-09-13T00:00:00Z
+
+	// There are changes before this, but no state.
+	minChangeset = 2007990 // 2016-09-07 10:45:02.148547780 Z
+)
+
+type stater struct {
+	Min     uint64
+	Current func(context.Context) (*State, error)
+	State   func(context.Context, uint64) (*State, error)
+}
+
+// MinuteStateAt will return the replication state/sequence number that contains
+// data for the given timestamp. This would be the first replication state written
+// after the timestamp. If the timestamp is after all current replication state
+// the most recent will be returned. The caller can check for this case using
+// state.Before(givenTimestamp).
+//
+// This call can do 20+ requests to the binary search the replication states.
+// Use sparingly or use a mirror.
+// Delegates to the DefaultDatasource and uses its http.Client to make the request.
+func MinuteStateAt(ctx context.Context, timestamp time.Time) (MinuteSeqNum, *State, error) {
+	return DefaultDatasource.MinuteStateAt(ctx, timestamp)
+}
+
+// MinuteStateAt will return the replication state/sequence number that contains
+// data for the given timestamp. This would be the first replication state written
+// after the timestamp. If the timestamp is after all current replication state
+// the most recent will be returned. The caller can check for this case using
+// state.Before(givenTimestamp).
+//
+// This call can do 20+ requests to the binary search the replication states.
+// Use sparingly or use a mirror.
+func (ds *Datasource) MinuteStateAt(ctx context.Context, timestamp time.Time) (MinuteSeqNum, *State, error) {
+	s := &stater{
+		Min: minMinute,
+		Current: func(ctx context.Context) (*State, error) {
+			_, s, err := ds.CurrentMinuteState(ctx)
+			return s, err
+		},
+		State: func(ctx context.Context, n uint64) (*State, error) {
+			return ds.MinuteState(ctx, MinuteSeqNum(n))
+		},
+	}
+	state, err := searchTimestamp(ctx, s, timestamp)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	return MinuteSeqNum(state.SeqNum), state, nil
+}
+
+// HourStateAt will return the replication state/sequence number that contains
+// data for the given timestamp. This would be the first replication state written
+// after the timestamp. If the timestamp is after all current replication state
+// the most recent will be returned. The caller can check for this case using
+// state.Before(givenTimestamp).
+//
+// This call can do 20+ requests to the binary search the replication states.
+// Use sparingly or use a mirror.
+// Delegates to the DefaultDatasource and uses its http.Client to make the request.
+func HourStateAt(ctx context.Context, timestamp time.Time) (HourSeqNum, *State, error) {
+	return DefaultDatasource.HourStateAt(ctx, timestamp)
+}
+
+// HourStateAt will return the replication state/sequence number that contains
+// data for the given timestamp. This would be the first replication state written
+// after the timestamp. If the timestamp is after all current replication state
+// the most recent will be returned. The caller can check for this case using
+// state.Before(givenTimestamp).
+//
+// This call can do 20+ requests to the binary search the replication states.
+// Use sparingly or use a mirror.
+func (ds *Datasource) HourStateAt(ctx context.Context, timestamp time.Time) (HourSeqNum, *State, error) {
+	s := &stater{
+		Min: minHour,
+		Current: func(ctx context.Context) (*State, error) {
+			_, s, err := ds.CurrentHourState(ctx)
+			return s, err
+		},
+		State: func(ctx context.Context, n uint64) (*State, error) {
+			return ds.HourState(ctx, HourSeqNum(n))
+		},
+	}
+	state, err := searchTimestamp(ctx, s, timestamp)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	return HourSeqNum(state.SeqNum), state, nil
+}
+
+// DayStateAt will return the replication state/sequence number that contains
+// data for the given timestamp. This would be the first replication state written
+// after the timestamp. If the timestamp is after all current replication state
+// the most recent will be returned. The caller can check for this case using
+// state.Before(givenTimestamp).
+//
+// This call can do 20+ requests to the binary search the replication states.
+// Use sparingly or use a mirror.
+// Delegates to the DefaultDatasource and uses its http.Client to make the request.
+func DayStateAt(ctx context.Context, timestamp time.Time) (DaySeqNum, *State, error) {
+	return DefaultDatasource.DayStateAt(ctx, timestamp)
+}
+
+// DayStateAt will return the replication state/sequence number that contains
+// data for the given timestamp. This would be the first replication state written
+// after the timestamp. If the timestamp is after all current replication state
+// the most recent will be returned. The caller can check for this case using
+// state.Before(givenTimestamp).
+//
+// This call can do 20+ requests to the binary search the replication states.
+// Use sparingly or use a mirror.
+func (ds *Datasource) DayStateAt(ctx context.Context, timestamp time.Time) (DaySeqNum, *State, error) {
+	s := &stater{
+		Min: minDay,
+		Current: func(ctx context.Context) (*State, error) {
+			_, s, err := ds.CurrentDayState(ctx)
+			return s, err
+		},
+		State: func(ctx context.Context, n uint64) (*State, error) {
+			return ds.DayState(ctx, DaySeqNum(n))
+		},
+	}
+	state, err := searchTimestamp(ctx, s, timestamp)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	return DaySeqNum(state.SeqNum), state, nil
+}
+
+// ChangesetStateAt will return the replication state/sequence number that contains
+// data for the given timestamp. This would be the first replication state written
+// after the timestamp. If the timestamp is after all current replication state
+// the most recent will be returned. The caller can check for this case using
+// state.Before(givenTimestamp).
+//
+// This call can do 20+ requests to the binary search the replication states.
+// Use sparingly or use a mirror.
+// Delegates to the DefaultDatasource and uses its http.Client to make the request.
+func ChangesetStateAt(ctx context.Context, timestamp time.Time) (ChangesetSeqNum, *State, error) {
+	return DefaultDatasource.ChangesetStateAt(ctx, timestamp)
+}
+
+// ChangesetStateAt will return the replication state/sequence number that contains
+// data for the given timestamp. This would be the first replication state written
+// after the timestamp. If the timestamp is after all current replication state
+// the most recent will be returned. The caller can check for this case using
+// state.Before(givenTimestamp).
+//
+// This call can do 20+ requests to the binary search the replication states.
+// Use sparingly or use a mirror.
+func (ds *Datasource) ChangesetStateAt(ctx context.Context, timestamp time.Time) (ChangesetSeqNum, *State, error) {
+	s := &stater{
+		Min: minDay,
+		Current: func(ctx context.Context) (*State, error) {
+			_, s, err := ds.CurrentChangesetState(ctx)
+			return s, err
+		},
+		State: func(ctx context.Context, n uint64) (*State, error) {
+			return ds.ChangesetState(ctx, ChangesetSeqNum(n))
+		},
+	}
+	state, err := searchTimestamp(ctx, s, timestamp)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	return ChangesetSeqNum(state.SeqNum), state, nil
+}
+
+func searchTimestamp(ctx context.Context, s *stater, timestamp time.Time) (*State, error) {
+	// get the current timestamp from the server
+	upper, err := s.Current(ctx)
+	if NotFound(err) {
+		return nil, err // current state not found?
+	} else if err != nil {
+		return nil, err
+	}
+
+	if timestamp.After(upper.Timestamp) {
+		return upper, nil // given time is in the future or something
+	}
+
+	lower, err := s.State(ctx, s.Min)
+	if err != nil && !NotFound(err) {
+		return nil, err
+	}
+
+	if lower == nil {
+		// now we need to find a lower bound state manually.
+		// This can have edge cases if there are missing sequence numbers.
+		var err error
+		lower, upper, err = findBound(ctx, s, upper, timestamp)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if lower.SeqNum+1 >= upper.SeqNum {
+		return lower, nil // edge case if there are only one or two sequence numbers
+	}
+
+	return findInRange(ctx, s, lower, upper, timestamp)
+}
+
+func findBound(ctx context.Context, s *stater, upper *State, timestamp time.Time) (*State, *State, error) {
+	var (
+		lowerID uint64 = 1
+		lower   *State
+		err     error
+	)
+
+	// we need to find the lower bound
+	for lower == nil {
+		lower, err = s.State(ctx, lowerID)
+
+		if err != nil && !NotFound(err) {
+			return nil, nil, err
+		}
+
+		if lower != nil && lower.Timestamp.After(timestamp) {
+			if lower.SeqNum+1 >= upper.SeqNum {
+				return lower, upper, nil // edge case if there are only two sequence numbers
+			}
+
+			// in our search for lower we found a new upper bound
+			upper = lower
+			lower = nil
+			lowerID = 1
+		}
+
+		if lower != nil {
+			break
+		}
+
+		// no lower yet, so try a higher id (binary search wise)
+		newID := (lowerID + upper.SeqNum) / 2
+		if newID <= lowerID {
+			// nothing suitable found, so upper is probably the best we can do
+			return upper, upper, nil
+		}
+		lowerID = newID
+	}
+
+	return lower, upper, nil
+}
+
+func findInRange(ctx context.Context, s *stater, lower, upper *State, timestamp time.Time) (*State, error) {
+	// we do a binary search through the range to find the sequence number
+	for lower.SeqNum+1 < upper.SeqNum {
+		// could do better here
+		splitID := (lower.SeqNum + upper.SeqNum) / 2
+
+		split, err := s.State(ctx, splitID)
+		if err != nil && !NotFound(err) {
+			return nil, err
+		}
+
+		if split == nil {
+			// file missing, search the next towards lower
+			sID := splitID - 1
+
+			for split == nil && lower.SeqNum < splitID {
+				split, err = s.State(ctx, sID)
+				if err != nil && !NotFound(err) {
+					return nil, err
+				}
+
+				sID--
+			}
+		}
+
+		if split == nil {
+			// still missing? search the next towards upper
+			sID := splitID + 1
+
+			for split == nil && splitID < upper.SeqNum {
+				split, err = s.State(ctx, sID)
+				if err != nil && !NotFound(err) {
+					return nil, err
+				}
+
+				sID++
+			}
+		}
+
+		if split == nil {
+			// still nothing
+			return lower, nil
+		}
+
+		// set the new boundary
+		if timestamp.After(split.Timestamp) {
+			lower = split
+		} else {
+			upper = split
+		}
+	}
+
+	// timestamp is now between lower and upper, we want to return the upper.
+	return upper, nil
+}

--- a/replication/search_test.go
+++ b/replication/search_test.go
@@ -1,0 +1,258 @@
+package replication
+
+import (
+	"context"
+	"math/rand"
+	"net/http"
+	"testing"
+	"time"
+)
+
+var baseTime = time.Date(2016, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// buildState is helper to build "valid" state files.
+func buildState(n int) *State {
+	d := time.Duration(n)
+	return &State{SeqNum: uint64(n), Timestamp: baseTime.Add(d * time.Hour)}
+}
+
+func TestSearchTimestamp(t *testing.T) {
+	t.Skip()
+	ctx := context.Background()
+
+	ts := &stater{
+		Min:     1,
+		Current: func(ctx context.Context) (*State, error) { return buildState(50), nil },
+		State: func(ctx context.Context, n uint64) (*State, error) {
+			states := map[uint64]*State{
+				5:  buildState(5),
+				10: buildState(10),
+				15: buildState(15),
+				20: buildState(20),
+				25: buildState(25),
+				30: buildState(30),
+			}
+
+			s := states[n]
+			if s == nil {
+				return nil, &UnexpectedStatusCodeError{Code: http.StatusNotFound}
+			}
+
+			return s, nil
+		},
+	}
+
+	cases := []struct {
+		name     string
+		time     time.Time
+		expected uint64
+	}{
+		{
+			name:     "before",
+			time:     baseTime,
+			expected: 5,
+		},
+		{
+			name:     "after",
+			time:     baseTime.Add(100 * time.Hour),
+			expected: 50,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, err := searchTimestamp(ctx, ts, tc.time)
+			if err != nil {
+				t.Fatalf("error getting timestamp: %v", err)
+			}
+
+			if s.SeqNum != tc.expected {
+				t.Errorf("incorrect seq number: %v != %v", s.SeqNum, tc.expected)
+			}
+		})
+	}
+}
+
+func TestFindBound(t *testing.T) {
+	ctx := context.Background()
+
+	ts := &stater{
+		Min:     1,
+		Current: func(ctx context.Context) (*State, error) { return buildState(9), nil },
+		State: func(ctx context.Context, n uint64) (*State, error) {
+			states := map[uint64]*State{
+				3: buildState(3),
+				4: buildState(4),
+				5: buildState(5),
+				6: buildState(6),
+				7: buildState(7),
+				8: buildState(8),
+			}
+
+			s := states[n]
+			if s == nil {
+				return nil, &UnexpectedStatusCodeError{Code: http.StatusNotFound}
+			}
+
+			return s, nil
+		},
+	}
+
+	cases := []struct {
+		name  string
+		time  time.Time
+		lower uint64
+		upper uint64
+	}{
+		{
+			name:  "before",
+			time:  baseTime,
+			lower: 3,
+			upper: 3,
+		},
+		{
+			name:  "middle before",
+			time:  baseTime.Add(6 * time.Hour).Add(30 * time.Minute),
+			lower: 5,
+			upper: 9,
+		},
+		{
+			name:  "middle after",
+			time:  baseTime.Add(4 * time.Hour).Add(30 * time.Minute),
+			lower: 3,
+			upper: 5,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			upper, _ := ts.Current(ctx)
+			lower, upper, err := findBound(ctx, ts, upper, tc.time)
+			if err != nil {
+				t.Fatalf("error getting timestamp: %v", err)
+			}
+
+			if lower.SeqNum != tc.lower {
+				t.Errorf("incorrect lower seq number: %v != %v", lower.SeqNum, tc.lower)
+			}
+
+			if upper.SeqNum != tc.upper {
+				t.Errorf("incorrect upper seq number: %v != %v", upper.SeqNum, tc.upper)
+			}
+		})
+	}
+}
+
+func TestMinuteStateAt(t *testing.T) {
+	liveOnly(t)
+
+	ctx := context.Background()
+
+	base := time.Date(2012, 9, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2022, 9, 1, 0, 0, 0, 0, time.UTC)
+	diff := int64(now.Sub(base)/time.Second + 10)
+
+	r := rand.New(rand.NewSource(42))
+
+	for i := 0; i < 10; i++ {
+		secs := r.Int63n(diff)
+		timestamp := base.Add(time.Duration(secs) * time.Second)
+
+		t.Logf("n: %d  timestamp: %v", i, timestamp)
+		_, state, err := MinuteStateAt(ctx, timestamp)
+		if err != nil {
+			t.Fatalf("failed to get state: %v", err)
+		}
+
+		if timestamp.After(state.Timestamp) {
+			_, current, err := CurrentMinuteState(ctx)
+			if err != nil {
+				t.Fatalf("could not get current state: %v", err)
+			}
+
+			if current.SeqNum != state.SeqNum {
+				t.Logf("state: %+v", state)
+				t.Fatalf("if timstamp is before, it must be the current timestamp")
+			}
+
+			continue
+		}
+
+		if state.SeqNum == minMinute {
+			// timestamp was before the first state
+			continue
+		}
+
+		// state's timestamp is after what we want
+		// get previous to make sure it before what we want
+		previous, err := MinuteState(ctx, MinuteSeqNum(state.SeqNum-1))
+		if err != nil {
+			t.Fatalf("could not get previous state: %v", err)
+		}
+
+		if !previous.Timestamp.Before(timestamp) {
+			t.Logf("prev:  %+v", previous)
+			t.Logf("state: %+v", state)
+			t.Fatalf("previus state not before timestamp")
+		}
+
+		t.Logf("found: %+v", state)
+	}
+}
+
+func TestChangesetStateAt(t *testing.T) {
+	liveOnly(t)
+
+	ctx := context.Background()
+
+	base := time.Date(2016, 9, 15, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2022, 9, 1, 0, 0, 0, 0, time.UTC)
+	diff := int64(now.Sub(base)/time.Second + 10)
+
+	r := rand.New(rand.NewSource(42))
+
+	for i := 0; i < 10; i++ {
+		secs := r.Int63n(diff)
+		timestamp := base.Add(time.Duration(secs) * time.Second)
+
+		t.Logf("n: %d  timestamp: %v", i, timestamp)
+		_, state, err := ChangesetStateAt(ctx, timestamp)
+		if err != nil {
+			t.Fatalf("failed to get state: %v", err)
+		}
+
+		if timestamp.After(state.Timestamp) {
+			_, current, err := CurrentChangesetState(ctx)
+			if err != nil {
+				t.Fatalf("could not get current state: %v", err)
+			}
+
+			if current.SeqNum != state.SeqNum {
+				t.Logf("state: %+v", state)
+				t.Fatalf("if timstamp is before, it must be the current timestamp")
+			}
+
+			continue
+		}
+
+		if state.SeqNum == minChangeset {
+			// timestamp was before the first state
+			continue
+		}
+
+		// state's timestamp is after what we want
+		// get previous to make sure it before what we want
+		previous, err := ChangesetState(ctx, ChangesetSeqNum(state.SeqNum-1))
+		if err != nil {
+			t.Fatalf("could not get previous state: %v", err)
+		}
+
+		if !previous.Timestamp.Before(timestamp) {
+			t.Logf("prev:  %+v", previous)
+			t.Logf("state: %+v", state)
+			t.Fatalf("previus state not before timestamp")
+		}
+
+		t.Logf("found: %+v", state)
+	}
+}


### PR DESCRIPTION
This PR add 4 methods to determine the sequence number from a given timestamp. They will return the state written after the given timestamp.

* `MinuteStateAt(ctx context.Context, timestamp time.Time) (MinuteSeqNum, *State, error)`
* `HourStateAt(ctx context.Context, timestamp time.Time) (HourSeqNum, *State, error)`
* `DayStateAt(ctx context.Context, timestamp time.Time) (DaySeqNum, *State, error)`
* `ChangesetStateAt(ctx context.Context, timestamp time.Time) (ChangesetSeqNum, *State, error)`

The binary search across the available states is based on https://github.com/osmcode/pyosmium/blob/000de57139f11cab1f22a99e7d9d3470f79f0947/src/osmium/replication/server.py#L197