### PR TITLE
osm: support version as json number or string

### DIFF
--- a/json.go
+++ b/json.go
@@ -27,7 +27,7 @@ import (
 // Note that any errors encountered during marshaling will be different.
 var CustomJSONMarshaler interface {
 	Marshal(v interface{}) ([]byte, error)
-} = nil
+}
 
 // CustomJSONUnmarshaler can be set to have the code use a different
 // json unmarshaler than the default in the standard library.
@@ -51,7 +51,7 @@ var CustomJSONMarshaler interface {
 // Note that any errors encountered during unmarshaling will be different.
 var CustomJSONUnmarshaler interface {
 	Unmarshal(data []byte, v interface{}) error
-} = nil
+}
 
 func marshalJSON(v interface{}) ([]byte, error) {
 	if CustomJSONMarshaler == nil {

--- a/osm.go
+++ b/osm.go
@@ -17,6 +17,8 @@ const (
 // OSM represents the core osm data
 // designed to parse http://wiki.openstreetmap.org/wiki/OSM_XML
 type OSM struct {
+	// JSON APIs can return version as a string or number, converted to string
+	// for consistency.
 	Version   string `xml:"version,attr,omitempty"`
 	Generator string `xml:"generator,attr,omitempty"`
 
@@ -286,7 +288,10 @@ func (o *OSM) marshalInnerElementsXML(e *xml.Encoder) error {
 // http://overpass-api.de/output_formats.html#json
 func (o *OSM) UnmarshalJSON(data []byte) error {
 	s := struct {
-		Version     string             `json:"version"`
+		// Version can be string or number,
+		// openstreetmap.org returns string
+		// overpass returns number
+		Version     interface{}        `json:"version"`
 		Generator   string             `json:"generator"`
 		Copyright   string             `json:"copyright"`
 		Attribution string             `json:"attribution"`
@@ -299,7 +304,7 @@ func (o *OSM) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	o.Version = s.Version
+	o.Version = fmt.Sprintf("%v", s.Version)
 	o.Generator = s.Generator
 	o.Copyright = s.Copyright
 	o.Attribution = s.Attribution

--- a/osm.go
+++ b/osm.go
@@ -370,7 +370,7 @@ func (o *OSM) UnmarshalJSON(data []byte) error {
 var jsonTypeRegexp = regexp.MustCompile(`"type"\s*:\s*"([^"]*)"`)
 
 func findType(index int, data []byte) (string, error) {
-	matches := jsonTypeRegexp.FindAllSubmatch(data, -1)
+	matches := jsonTypeRegexp.FindAllSubmatch(data, 1)
 	if len(matches) > 0 {
 		return string(matches[0][1]), nil
 	}

--- a/osm_test.go
+++ b/osm_test.go
@@ -226,6 +226,24 @@ func TestOSM_UnmarshalJSON(t *testing.T) {
 	}
 }
 
+func TestOSM_UnmarshalJSON_Version(t *testing.T) {
+	data := []byte(`{
+		"version":0.6,"generator":"osm-go",
+		"elements":[
+		  {"type":"node","id":123,"lat":0,"lon":0,"visible":false,"timestamp":"0001-01-01T00:00:00Z"}
+		]}`)
+
+	o := &OSM{}
+	err := json.Unmarshal(data, &o)
+	if err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if o.Version != "0.6" {
+		t.Errorf("incorrect version %v != 0.6", o.Version)
+	}
+}
+
 func TestOSM_MarshalXML(t *testing.T) {
 	o := &OSM{
 		Version:     "0.7",


### PR DESCRIPTION
The OSM object has a version field. This can be a number or string:
* openstreetmap.org returns version as string https://www.openstreetmap.org/api/0.6/node/1.json
* overpass returns it as a number http://overpass-api.de/output_formats.html#json

This PR adds support for the number case and converts it to a string to be stored on the OSM object.

See issue https://github.com/paulmach/osm/issues/44