### PR TITLE
add cgo and pkg-config info to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,16 @@ benchmark                            old bytes     new bytes     delta
 BenchmarkChange_MarshalJSON-12       180583        162727        -9.89%
 BenchmarkChange_UnmarshalJSON-12     287707        317723        +10.43%
 ```
+
+## CGO and zlib
+
+OSM PBF data comes in blocks, each block is zlib compressed. Decompressing this
+data takes about 33% of the total read time. [DataDog/czlib](https://github.com/DataDog/czlib) is
+used to speed this process.
+See [osmpbf/README.md](osmpbf#using-cgoczlib-for-decompression) for more details.
+
+As a result, a C compiler is necessary to install this module. On macOS this may require
+installing pkg-config using something like `brew install pkg-config`
+
+CGO can be disabled at build time using the `CGO_ENABLED` ENV variable.
+For example, `CGO_ENABLED=0 go build`. The code will fallback to the stdlib implementation of zlib.

--- a/osmpbf/README.md
+++ b/osmpbf/README.md
@@ -80,7 +80,7 @@ This package supports reading OSM PBF files where the ways have been annotated w
 
 Coordinates are stored in the `Lat` and `Lon` fields of each `WayNode`. There is no need to specify an explicit option; when the node locations are present on the ways, they are loaded automatically. For more info about the OSM PBF format extension, see [the original blog post](https://blog.jochentopf.com/2016-04-20-node-locations-on-ways.html).
 
-### Using cgo/czlib for decompression
+## Using cgo/czlib for decompression
 
 OSM PBF files are a set of blocks that are zlib compressed. When using the pure golang
 implementation this can account for about 1/3 of the read time. When cgo is enabled


### PR DESCRIPTION
As discussed in https://github.com/paulmach/osm/issues/43

Since CGO is used for zlib decompression of the pbf data, you may need build tools installed to build/install this module.