### PR TITLE
correctly unmarshal elements with a type tag

### DIFF
--- a/osm.go
+++ b/osm.go
@@ -3,7 +3,6 @@ package osm
 import (
 	"encoding/xml"
 	"fmt"
-	"regexp"
 )
 
 // These values should be returned if the osm data is actual
@@ -367,13 +366,21 @@ func (o *OSM) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-var jsonTypeRegexp = regexp.MustCompile(`"type"\s*:\s*"([^"]*)"`)
+type typeStruct struct {
+	Type string `json:"type"`
+}
 
 func findType(index int, data []byte) (string, error) {
-	matches := jsonTypeRegexp.FindAllSubmatch(data, 1)
-	if len(matches) > 0 {
-		return string(matches[0][1]), nil
+	ts := typeStruct{}
+	err := unmarshalJSON(data, &ts)
+	if err != nil {
+		// should not happened due to previous decoding succeeded
+		return "", err
 	}
 
-	return "", fmt.Errorf("could not find type in element index %d", index)
+	if ts.Type == "" {
+		return "", fmt.Errorf("could not find type in element index %d", index)
+	}
+
+	return ts.Type, nil
 }

--- a/osm_test.go
+++ b/osm_test.go
@@ -183,7 +183,10 @@ func TestOSM_UnmarshalJSON(t *testing.T) {
 		  {"type":"way","id":456,"visible":false,"timestamp":"0001-01-01T00:00:00Z","nodes":[]},
 		  {"type":"relation","id":789,"visible":false,"timestamp":"0001-01-01T00:00:00Z","members":[]},
 		  {"type":"changeset","id":10,"created_at":"0001-01-01T00:00:00Z","closed_at":"0001-01-01T00:00:00Z","open":false},
-		  {"type":"user","id":16,"name":"","img":{"href":""},"changesets":{"count":0},"traces":{"count":0},"home":{"lat":0,"lon":0,"zoom":0},"languages":null,"blocks":{"received":{"count":0,"active":0}},"messages":{"received":{"count":0,"unread":0},"sent":{"count":0}},"created_at":"0001-01-01T00:00:00Z"},
+		  {"type":"user","id":16,"name":"","img":{"href":""},
+		   "changesets":{"count":0},"traces":{"count":0},"home":{"lat":0,"lon":0,"zoom":0},"languages":null,
+		   "blocks":{"received":{"count":0,"active":0}},"messages":{"received":{"count":0,"unread":0},"sent":{"count":0}},
+		   "created_at":"0001-01-01T00:00:00Z"},
 		  {"type":"note","id":15,"lat":0,"lon":0,"date_created":null,"date_closed":null,"comments":null}
 		]}`)
 
@@ -241,6 +244,25 @@ func TestOSM_UnmarshalJSON_Version(t *testing.T) {
 
 	if o.Version != "0.6" {
 		t.Errorf("incorrect version %v != 0.6", o.Version)
+	}
+}
+
+func TestOSM_UnmarshalJSON_Type(t *testing.T) {
+	data := []byte(`{
+		"version":0.6,"generator":"osm-go",
+		"elements":[
+			{"type":"relation","id":120,"timestamp":"0001-01-01T00:00:00Z","tags":{"type":"route"}},
+			{"tags":{"type":"route","other":"asdf"},"type":"relation","id":121,"timestamp":"0001-01-01T00:00:00Z"}
+		]}`)
+
+	o := &OSM{}
+	err := json.Unmarshal(data, &o)
+	if err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if l := len(o.Relations); l != 2 {
+		t.Errorf("incorrect number of relations: %v", l)
 	}
 }
 


### PR DESCRIPTION
as described in https://github.com/paulmach/osm/issues/51 the "quick hack" to find the type does not work if the the element has `"tags":{"type":"route"}` like relations have.

This PR finds the tag using an unmarshal, it does impact performance. 
```
benchmark                            old ns/op     new ns/op     delta
BenchmarkChange_UnmarshalJSON-10     1099707       1331954       +21.12%

benchmark                            old allocs     new allocs     delta
BenchmarkChange_UnmarshalJSON-10     4880           5327           +9.16%

benchmark                            old bytes     new bytes     delta
BenchmarkChange_UnmarshalJSON-10     273049        252964        -7.36%
```

I was able to get it down to +7% speed but much more memory using `json.Decoder.Token`. I opted for the simpler approach as it allowed the plugging in of "customer unmarshallers". 

If performance is a concern consider using [jsoniter](github.com/json-iterator/go) or similar like
```
import (
  jsoniter "github.com/json-iterator/go"
  "github.com/paulmach/osm"
)

var c = jsoniter.Config{
  EscapeHTML:              true,
  SortMapKeys:             false,
  ValidateJsonRawMessage:  false,
  MarshalFloatWith6Digits: true,
}.Froze()

osm.CustomJSONMarshaler = c
osm.CustomJSONUnmarshaler = c
```