### PR TITLE
support negative object/feature/element ids

### DIFF
--- a/changeset.go
+++ b/changeset.go
@@ -10,7 +10,7 @@ type ChangesetID int64
 
 // ObjectID is a helper returning the object id for this changeset id.
 func (id ChangesetID) ObjectID() ObjectID {
-	return ObjectID(changesetMask | (id << versionBits))
+	return ObjectID(changesetMask | ((id << versionBits) & refVersionMask))
 }
 
 // Changesets is a collection with some helper functions attached.

--- a/changeset_test.go
+++ b/changeset_test.go
@@ -262,9 +262,9 @@ func TestChangeset_MarshalXML(t *testing.T) {
 }
 
 func TestChangesets_IDs(t *testing.T) {
-	cs := Changesets{{ID: 1}, {ID: 2}}
+	cs := Changesets{{ID: 1}, {ID: 2}, {ID: -3}}
 
-	csids := []ChangesetID{1, 2}
+	csids := []ChangesetID{1, 2, -3}
 	if ids := cs.IDs(); !reflect.DeepEqual(ids, csids) {
 		t.Errorf("incorrect changeset id: %v", csids)
 	}

--- a/element.go
+++ b/element.go
@@ -34,7 +34,12 @@ func (id ElementID) Type() Type {
 
 // Ref return the ID reference for the element. Not unique without the type.
 func (id ElementID) Ref() int64 {
-	return int64((id & refMask) >> versionBits)
+	// handle negative ids correctly, if negative top 24 bits need to be set as 1
+	// want to do this in a non-branching way
+	// - shift left until 25th bit is now at first position
+	// - shift right back to original position,
+	//   this option fill with same as the first position
+	return (int64((id&refMask)>>versionBits) << typeVersionBits) >> typeVersionBits
 }
 
 // Version returns the version of the element.
@@ -180,7 +185,14 @@ type elementsSort Elements
 func (es elementsSort) Len() int      { return len(es) }
 func (es elementsSort) Swap(i, j int) { es[i], es[j] = es[j], es[i] }
 func (es elementsSort) Less(i, j int) bool {
-	return es[i].ElementID() < es[j].ElementID()
+	iid := es[i].ElementID()
+	jid := es[j].ElementID()
+
+	if iid&typeMask != jid&typeMask {
+		return iid&typeMask < jid&typeMask
+	}
+
+	return ((iid << typeVersionBits) >> typeVersionBits) < ((jid << typeVersionBits) >> typeVersionBits)
 }
 
 // ElementIDs is a list of element ids with helper functions on top.
@@ -213,5 +225,8 @@ func (ids ElementIDs) Sort() {
 func (ids elementIDsSort) Len() int      { return len(ids) }
 func (ids elementIDsSort) Swap(i, j int) { ids[i], ids[j] = ids[j], ids[i] }
 func (ids elementIDsSort) Less(i, j int) bool {
-	return ids[i] < ids[j]
+	if ids[i]&typeMask != ids[j]&typeMask {
+		return ids[i]&typeMask < ids[j]&typeMask
+	}
+	return ((ids[i] << typeVersionBits) >> typeVersionBits) < ((ids[j] << typeVersionBits) >> typeVersionBits)
 }

--- a/element_test.go
+++ b/element_test.go
@@ -27,11 +27,23 @@ func TestElementID_ids(t *testing.T) {
 		t.Errorf("incorrect id: %v", v)
 	}
 
+	if v := NodeID(-1).ElementID(1).NodeID(); v != -1 {
+		t.Errorf("incorrect id: %v", v)
+	}
+
 	if v := NodeID(1).ElementID(1).NodeID(); v != 1 {
 		t.Errorf("incorrect id: %v", v)
 	}
 
+	if v := WayID(-1).ElementID(1).WayID(); v != -1 {
+		t.Errorf("incorrect id: %v", v)
+	}
+
 	if v := WayID(1).ElementID(1).WayID(); v != 1 {
+		t.Errorf("incorrect id: %v", v)
+	}
+
+	if v := RelationID(-1).ElementID(1).RelationID(); v != -1 {
 		t.Errorf("incorrect id: %v", v)
 	}
 
@@ -79,6 +91,10 @@ func TestParseElementID(t *testing.T) {
 		string string
 		id     ElementID
 	}{
+		{
+			name: "negative id",
+			id:   NodeID(-1).ElementID(1),
+		},
 		{
 			name: "node",
 			id:   NodeID(0).ElementID(1),
@@ -232,6 +248,7 @@ func TestElements_Sort(t *testing.T) {
 	es := Elements{
 		&Node{ID: 1, Version: 4},
 		&Node{ID: 1, Version: 5},
+		&Node{ID: -1, Version: 5},
 		&Way{ID: 2, Version: 6},
 		&Relation{ID: 3, Version: 7},
 		&Way{ID: 2, Version: 5},
@@ -240,6 +257,7 @@ func TestElements_Sort(t *testing.T) {
 	es.Sort()
 
 	expected := ElementIDs{
+		NodeID(-1).ElementID(5),
 		NodeID(1).ElementID(4),
 		NodeID(1).ElementID(5),
 		NodeID(4).ElementID(8),
@@ -279,12 +297,16 @@ func TestElementIDs_Sort(t *testing.T) {
 	ids := ElementIDs{
 		RelationID(1).ElementID(1),
 		NodeID(1).ElementID(2),
+		NodeID(-1).ElementID(3),
+		NodeID(-1).ElementID(2),
 		WayID(2).ElementID(3),
 		WayID(1).ElementID(2),
 		WayID(1).ElementID(1),
 	}
 
 	expected := ElementIDs{
+		NodeID(-1).ElementID(2),
+		NodeID(-1).ElementID(3),
 		NodeID(1).ElementID(2),
 		WayID(1).ElementID(1),
 		WayID(1).ElementID(2),

--- a/feature.go
+++ b/feature.go
@@ -67,6 +67,9 @@ const (
 	featureMask = 0x7FFFFFFFFFFF0000
 	typeMask    = 0x7F00000000000000
 
+	refVersionMask = refMask | versionMask
+
+	typeBits      = 8
 	boundsMask    = 0x0800000000000000
 	nodeMask      = 0x1000000000000000
 	wayMask       = 0x2000000000000000
@@ -74,6 +77,8 @@ const (
 	changesetMask = 0x4000000000000000
 	noteMask      = 0x5000000000000000
 	userMask      = 0x6000000000000000
+
+	typeVersionBits = typeBits + versionBits
 )
 
 // A FeatureID is an identifier for a feature in OSM.
@@ -97,7 +102,12 @@ func (id FeatureID) Type() Type {
 
 // Ref return the ID reference for the feature. Not unique without the type.
 func (id FeatureID) Ref() int64 {
-	return int64((id & refMask) >> versionBits)
+	// handle negative ids correctly, if negative top 24 bits need to be set as 1
+	// want to do this in a non-branching way
+	// - shift left until 25th bit is now at first position
+	// - shift right back to original position,
+	//   this option fill with same as the first position
+	return (int64((id&refMask)>>versionBits) << typeVersionBits) >> typeVersionBits
 }
 
 // ObjectID is a helper to convert the id to an object id.
@@ -205,5 +215,8 @@ func (ids FeatureIDs) Sort() {
 func (ids featureIDsSort) Len() int      { return len(ids) }
 func (ids featureIDsSort) Swap(i, j int) { ids[i], ids[j] = ids[j], ids[i] }
 func (ids featureIDsSort) Less(i, j int) bool {
-	return ids[i] < ids[j]
+	if ids[i]&typeMask != ids[j]&typeMask {
+		return ids[i]&typeMask < ids[j]&typeMask
+	}
+	return ids[i].Ref() < ids[j].Ref()
 }

--- a/feature_test.go
+++ b/feature_test.go
@@ -35,11 +35,23 @@ func TestFeatureID_ids(t *testing.T) {
 		t.Errorf("incorrect version: %v", v)
 	}
 
+	if v := NodeID(-1).FeatureID().NodeID(); v != -1 {
+		t.Errorf("incorrect id: %v", v)
+	}
+
 	if v := NodeID(1).FeatureID().NodeID(); v != 1 {
 		t.Errorf("incorrect id: %v", v)
 	}
 
+	if v := WayID(-1).FeatureID().WayID(); v != -1 {
+		t.Errorf("incorrect id: %v", v)
+	}
+
 	if v := WayID(1).FeatureID().WayID(); v != 1 {
+		t.Errorf("incorrect id: %v", v)
+	}
+
+	if v := RelationID(-1).FeatureID().RelationID(); v != -1 {
 		t.Errorf("incorrect id: %v", v)
 	}
 
@@ -94,6 +106,11 @@ func TestFeature_String(t *testing.T) {
 		id       FeatureID
 		expected string
 	}{
+		{
+			name:     "node",
+			id:       NodeID(-1).FeatureID(),
+			expected: "node/-1",
+		},
 		{
 			name:     "node",
 			id:       NodeID(1).FeatureID(),
@@ -200,12 +217,14 @@ func TestFeatureIDs_Counts(t *testing.T) {
 func TestFeatureIDs_Sort(t *testing.T) {
 	ids := FeatureIDs{
 		RelationID(1).FeatureID(),
+		NodeID(-1).FeatureID(),
 		NodeID(1).FeatureID(),
 		WayID(2).FeatureID(),
 		WayID(1).FeatureID(),
 	}
 
 	expected := FeatureIDs{
+		NodeID(-1).FeatureID(),
 		NodeID(1).FeatureID(),
 		WayID(1).FeatureID(),
 		WayID(2).FeatureID(),

--- a/node.go
+++ b/node.go
@@ -18,7 +18,7 @@ func (id NodeID) ObjectID(v int) ObjectID {
 
 // FeatureID is a helper returning the feature id for this node id.
 func (id NodeID) FeatureID() FeatureID {
-	return FeatureID(nodeMask | (id << versionBits))
+	return FeatureID(nodeMask | ((id << versionBits) & refVersionMask))
 }
 
 // ElementID is a helper to convert the id to an element id.

--- a/node_test.go
+++ b/node_test.go
@@ -90,19 +90,28 @@ func TestNodes_ids(t *testing.T) {
 	ns := Nodes{
 		{ID: 1, Version: 3},
 		{ID: 2, Version: 4},
+		{ID: -3, Version: 5},
 	}
 
-	eids := ElementIDs{NodeID(1).ElementID(3), NodeID(2).ElementID(4)}
+	eids := ElementIDs{
+		NodeID(1).ElementID(3),
+		NodeID(2).ElementID(4),
+		NodeID(-3).ElementID(5),
+	}
 	if ids := ns.ElementIDs(); !reflect.DeepEqual(ids, eids) {
 		t.Errorf("incorrect element ids: %v", ids)
 	}
 
-	fids := FeatureIDs{NodeID(1).FeatureID(), NodeID(2).FeatureID()}
+	fids := FeatureIDs{
+		NodeID(1).FeatureID(),
+		NodeID(2).FeatureID(),
+		NodeID(-3).FeatureID(),
+	}
 	if ids := ns.FeatureIDs(); !reflect.DeepEqual(ids, fids) {
 		t.Errorf("incorrect feature ids: %v", ids)
 	}
 
-	nids := []NodeID{1, 2}
+	nids := []NodeID{1, 2, -3}
 	if ids := ns.IDs(); !reflect.DeepEqual(ids, nids) {
 		t.Errorf("incorrect node ids: %v", nids)
 	}
@@ -113,7 +122,7 @@ func TestNodes_SortByIDVersion(t *testing.T) {
 		{ID: 7, Version: 3},
 		{ID: 2, Version: 4},
 		{ID: 5, Version: 2},
-		{ID: 5, Version: 3},
+		{ID: -1, Version: 3},
 		{ID: 5, Version: 4},
 		{ID: 3, Version: 4},
 		{ID: 4, Version: 4},
@@ -123,11 +132,11 @@ func TestNodes_SortByIDVersion(t *testing.T) {
 	ns.SortByIDVersion()
 
 	eids := ElementIDs{
+		NodeID(-1).ElementID(3),
 		NodeID(2).ElementID(4),
 		NodeID(3).ElementID(4),
 		NodeID(4).ElementID(4),
 		NodeID(5).ElementID(2),
-		NodeID(5).ElementID(3),
 		NodeID(5).ElementID(4),
 		NodeID(7).ElementID(3),
 		NodeID(9).ElementID(4),

--- a/note.go
+++ b/note.go
@@ -10,7 +10,7 @@ type NoteID int64
 
 // ObjectID is a helper returning the object id for this note id.
 func (id NoteID) ObjectID() ObjectID {
-	return ObjectID(noteMask | (id << versionBits))
+	return ObjectID(noteMask | ((id << versionBits) & refVersionMask))
 }
 
 const dateLayout = "2006-01-02 15:04:05 MST"

--- a/note_test.go
+++ b/note_test.go
@@ -167,6 +167,18 @@ func TestNote_ObjectID(t *testing.T) {
 	}
 
 	if v := id.Ref(); v != 123 {
-		t.Errorf("incorrect ref: %v", 123)
+		t.Errorf("incorrect ref: %v", v)
+	}
+
+	// negative id
+	n = Note{ID: -123}
+	id = n.ObjectID()
+
+	if v := id.Type(); v != TypeNote {
+		t.Errorf("incorrect type: %v", v)
+	}
+
+	if v := id.Ref(); v != -123 {
+		t.Errorf("incorrect ref: %v", v)
 	}
 }

--- a/object.go
+++ b/object.go
@@ -34,7 +34,12 @@ func (id ObjectID) Type() Type {
 
 // Ref returns the ID reference for the object. Not unique without the type.
 func (id ObjectID) Ref() int64 {
-	return int64((id & refMask) >> versionBits)
+	// handle negative ids correctly, if negative top 24 bits need to be set as 1
+	// want to do this in a non-branching way
+	// - shift left until 25th bit is now at first position
+	// - shift right back to original position,
+	//   this option fill with same as the first position
+	return (int64((id&refMask)>>versionBits) << typeVersionBits) >> typeVersionBits
 }
 
 // Version returns the version of the object.

--- a/object_test.go
+++ b/object_test.go
@@ -20,6 +20,10 @@ func TestParseObjectID(t *testing.T) {
 			id:   NodeID(3).ObjectID(0),
 		},
 		{
+			name: "negative id",
+			id:   NodeID(-3).ObjectID(10),
+		},
+		{
 			name: "way",
 			id:   WayID(10).ObjectID(2),
 		},
@@ -103,6 +107,7 @@ func TestParseObjectID(t *testing.T) {
 func TestObjects_ObjectIDs(t *testing.T) {
 	es := Objects{
 		&Node{ID: 1, Version: 5},
+		&Node{ID: -1, Version: 5},
 		&Way{ID: 2, Version: 6},
 		&Relation{ID: 3, Version: 7},
 		&Node{ID: 4, Version: 8},
@@ -112,6 +117,7 @@ func TestObjects_ObjectIDs(t *testing.T) {
 
 	expected := ObjectIDs{
 		NodeID(1).ObjectID(5),
+		NodeID(-1).ObjectID(5),
 		WayID(2).ObjectID(6),
 		RelationID(3).ObjectID(7),
 		NodeID(4).ObjectID(8),

--- a/osmxml/scanner_test.go
+++ b/osmxml/scanner_test.go
@@ -159,6 +159,31 @@ func TestScanner_bounds(t *testing.T) {
 	}
 }
 
+func TestScanner_negativeId(t *testing.T) {
+	f, err := os.Open("testdata/error.xml")
+	if err != nil {
+		t.Fatalf("could not open file: %v", err)
+	}
+	defer f.Close()
+
+	scanner := New(context.Background(), f)
+	defer scanner.Close()
+
+	// just check the first node
+	scanner.Scan()
+
+	o := scanner.Object()
+	oid := o.ObjectID()
+
+	if v := oid.Type(); v != "node" {
+		t.Errorf("type should be node, got %v", v)
+	}
+
+	if v := oid.Ref(); v != -25490 {
+		t.Errorf("id incorrect, got %0x ", v)
+	}
+}
+
 func TestAndorra(t *testing.T) {
 	f, err := os.Open("../testdata/andorra-latest.osm.bz2")
 	if err != nil {

--- a/osmxml/testdata/error.xml
+++ b/osmxml/testdata/error.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-25490' action='modify' visible='true' lat='-8.07731878077' lon='-34.89726501704' />
+  <node id='2503966846' timestamp='2015-09-29T18:24:39Z' uid='1772173' user='plguedes' visible='true' version='2' changeset='34332332' lat='-8.0769279' lon='-34.8973969' />
+  <node id='2503966854' timestamp='2020-02-26T15:56:11Z' uid='9535235' user='Metaxourgeio' visible='true' version='4' changeset='81511274' lat='-8.0776001' lon='-34.8971701' />
+  <way id='242959928' action='modify' timestamp='2024-10-17T23:06:04Z' uid='4102129' user='raphaelmirc' visible='true' version='6' changeset='158029161'>
+    <nd ref='2503966854' />
+    <nd ref='-25490' />
+    <nd ref='2503966846' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='Rua Pacatuba' />
+    <tag k='oneway' v='yes' />
+    <tag k='postal_code' v='50090-570' />
+    <tag k='source:postal_code' v='CNEFE' />
+    <tag k='surface' v='asphalt' />
+  </way>
+</osm>

--- a/relation.go
+++ b/relation.go
@@ -18,7 +18,7 @@ func (id RelationID) ObjectID(v int) ObjectID {
 
 // FeatureID is a helper returning the feature id for this relation id.
 func (id RelationID) FeatureID() FeatureID {
-	return FeatureID(relationMask | id<<versionBits)
+	return FeatureID(relationMask | ((id << versionBits) & refVersionMask))
 }
 
 // ElementID is a helper to convert the id to an element id.

--- a/relation_test.go
+++ b/relation_test.go
@@ -305,19 +305,28 @@ func TestRelations_ids(t *testing.T) {
 	rs := Relations{
 		{ID: 1, Version: 3},
 		{ID: 2, Version: 4},
+		{ID: -3, Version: 5},
 	}
 
-	eids := ElementIDs{RelationID(1).ElementID(3), RelationID(2).ElementID(4)}
+	eids := ElementIDs{
+		RelationID(1).ElementID(3),
+		RelationID(2).ElementID(4),
+		RelationID(-3).ElementID(5),
+	}
 	if ids := rs.ElementIDs(); !reflect.DeepEqual(ids, eids) {
 		t.Errorf("incorrect element ids: %v", ids)
 	}
 
-	fids := FeatureIDs{RelationID(1).FeatureID(), RelationID(2).FeatureID()}
+	fids := FeatureIDs{
+		RelationID(1).FeatureID(),
+		RelationID(2).FeatureID(),
+		RelationID(-3).FeatureID(),
+	}
 	if ids := rs.FeatureIDs(); !reflect.DeepEqual(ids, fids) {
 		t.Errorf("incorrect feature ids: %v", ids)
 	}
 
-	rids := []RelationID{1, 2}
+	rids := []RelationID{1, 2, -3}
 	if ids := rs.IDs(); !reflect.DeepEqual(ids, rids) {
 		t.Errorf("incorrect node id: %v", rids)
 	}

--- a/user.go
+++ b/user.go
@@ -10,7 +10,7 @@ type UserID int64
 
 // ObjectID is a helper returning the object id for this user id.
 func (id UserID) ObjectID() ObjectID {
-	return ObjectID(userMask | (id << versionBits))
+	return ObjectID(userMask | ((id << versionBits) & refVersionMask))
 }
 
 // Users is a collection of users with some helpers attached.

--- a/user_test.go
+++ b/user_test.go
@@ -132,7 +132,19 @@ func TestUser_ObjectID(t *testing.T) {
 	}
 
 	if v := id.Ref(); v != 123 {
-		t.Errorf("incorrect ref: %v", 123)
+		t.Errorf("incorrect ref: %v", v)
+	}
+
+	// negative id
+	u = User{ID: -123}
+	id = u.ObjectID()
+
+	if v := id.Type(); v != TypeUser {
+		t.Errorf("incorrect type: %v", v)
+	}
+
+	if v := id.Ref(); v != -123 {
+		t.Errorf("incorrect ref: %v", v)
 	}
 }
 


### PR DESCRIPTION
as brought up in https://github.com/paulmach/osm/issues/63 negative ids don't work. This PR adds support for them.

I believe editors use negative ids to differentiate new nodes from existing nodes. The create/commit api them gives them real ids.  At least this was the case when I last looked, which was a while ago. 