### PR TITLE
osmpbf: bounds-check string table indexes to avoid decoder panic

### DIFF
--- a/osmpbf/decode_data.go
+++ b/osmpbf/decode_data.go
@@ -2,12 +2,13 @@ package osmpbf
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
-	"google.golang.org/protobuf/proto"
 	"github.com/paulmach/osm"
 	"github.com/paulmach/osm/osmpbf/internal/osmpbf"
 	"github.com/paulmach/protoscan"
+	"google.golang.org/protobuf/proto"
 )
 
 // dataDecoder is a decoder for Blob with OSMData (PrimitiveBlock).
@@ -426,7 +427,11 @@ func (dec *dataDecoder) extractDenseNodes() error {
 				return err
 			}
 			usid += v6
-			n.User = st[usid]
+			user, err := stringTableString(st, int(usid))
+			if err != nil {
+				return err
+			}
+			n.User = user
 		}
 
 		// Visible
@@ -486,7 +491,15 @@ func (dec *dataDecoder) extractDenseNodes() error {
 					return err
 				}
 
-				n.Tags = append(n.Tags, osm.Tag{Key: st[k], Value: st[v]})
+				key, err := stringTableString(st, int(k))
+				if err != nil {
+					return err
+				}
+				val, err := stringTableString(st, int(v))
+				if err != nil {
+					return err
+				}
+				n.Tags = append(n.Tags, osm.Tag{Key: key, Value: val})
 			}
 		}
 
@@ -570,7 +583,11 @@ func (dec *dataDecoder) scanWays(data []byte, way *osm.Way) (*osm.Way, error) {
 					if err != nil {
 						return nil, err
 					}
-					way.User = st[v]
+					user, err := stringTableString(st, int(v))
+					if err != nil {
+						return nil, err
+					}
+					way.User = user
 				case 6:
 					v, err := info.Bool()
 					if err != nil {
@@ -681,7 +698,11 @@ func extractMembers(
 		if err != nil {
 			return nil, err
 		}
-		members[index].Role = st[r]
+		role, err := stringTableString(st, int(r))
+		if err != nil {
+			return nil, err
+		}
+		members[index].Role = role
 
 		m, err := memids.Sint64()
 		if err != nil {
@@ -774,7 +795,11 @@ func (dec *dataDecoder) scanRelations(data []byte, relation *osm.Relation) (*osm
 					if err != nil {
 						return nil, err
 					}
-					relation.User = st[v]
+					user, err := stringTableString(st, int(v))
+					if err != nil {
+						return nil, err
+					}
+					relation.User = user
 				case 6:
 					v, err := info.Bool()
 					if err != nil {
@@ -834,7 +859,6 @@ func (dec *dataDecoder) scanRelations(data []byte, relation *osm.Relation) (*osm
 
 func scanTags(stringTable []string, keys, vals *protoscan.Iterator) (osm.Tags, error) {
 	// note we assume keys and vals are the same length
-	// we also assume index are within range of the stringTable
 
 	index := 0
 	tags := make(osm.Tags, keys.Count(protoscan.WireTypeVarint))
@@ -847,12 +871,31 @@ func scanTags(stringTable []string, keys, vals *protoscan.Iterator) (osm.Tags, e
 		if err != nil {
 			return nil, err
 		}
+		key, err := stringTableString(stringTable, int(k))
+		if err != nil {
+			return nil, err
+		}
+		val, err := stringTableString(stringTable, int(v))
+		if err != nil {
+			return nil, err
+		}
 		tags[index] = osm.Tag{
-			Key:   stringTable[k],
-			Value: stringTable[v],
+			Key:   key,
+			Value: val,
 		}
 		index++
 	}
 
 	return tags, nil
+}
+
+// stringTableString returns stringTable[i], guarding against an out-of-range
+// index. In a PrimitiveBlock the key, value, role and user fields are indexes
+// into the block's string table; a corrupt or malicious file can reference an
+// index past the end of the table, which would otherwise panic the decoder.
+func stringTableString(stringTable []string, i int) (string, error) {
+	if i < 0 || i >= len(stringTable) {
+		return "", fmt.Errorf("osmpbf: string table index %d out of range [0, %d)", i, len(stringTable))
+	}
+	return stringTable[i], nil
 }

--- a/osmpbf/decode_stringtable_test.go
+++ b/osmpbf/decode_stringtable_test.go
@@ -1,0 +1,128 @@
+package osmpbf
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"strings"
+	"testing"
+
+	"github.com/paulmach/osm/osmpbf/internal/osmpbf"
+	"google.golang.org/protobuf/proto"
+)
+
+// writeFileBlock writes a single OSM PBF file block (a big-endian uint32
+// BlobHeader length, the BlobHeader, then the uncompressed Blob) to buf.
+func writeFileBlock(t *testing.T, buf *bytes.Buffer, blockType string, payload []byte) {
+	t.Helper()
+
+	blob, err := proto.Marshal(&osmpbf.Blob{Raw: payload})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dataSize := int32(len(blob))
+	header, err := proto.Marshal(&osmpbf.BlobHeader{
+		Type:     proto.String(blockType),
+		Datasize: &dataSize,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var size [4]byte
+	binary.BigEndian.PutUint32(size[:], uint32(len(header)))
+	buf.Write(size[:])
+	buf.Write(header)
+	buf.Write(blob)
+}
+
+// pbfWithGroup returns a minimal, valid-framing PBF stream: an OSMHeader block
+// followed by an OSMData block whose PrimitiveBlock has a single-entry string
+// table and the given primitive group.
+func pbfWithGroup(t *testing.T, group *osmpbf.PrimitiveGroup) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	header, err := proto.Marshal(&osmpbf.HeaderBlock{
+		RequiredFeatures: []string{"OsmSchema-V0.6", "DenseNodes"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFileBlock(t, &buf, "OSMHeader", header)
+
+	block, err := proto.Marshal(&osmpbf.PrimitiveBlock{
+		Stringtable:    &osmpbf.StringTable{S: []string{""}},
+		Primitivegroup: []*osmpbf.PrimitiveGroup{group},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFileBlock(t, &buf, "OSMData", block)
+
+	return buf.Bytes()
+}
+
+// A string table index that references an entry beyond the (single-entry)
+// string table used by pbfWithGroup.
+const outOfRangeIndex = 5
+
+// TestOutOfRangeStringTableIndex verifies that a string table index pointing
+// past the end of the table produces an error instead of panicking the
+// decoder. The key/value/role/user fields of ways, relations and dense nodes
+// are all indexes into the block's string table and are attacker controlled.
+func TestOutOfRangeStringTableIndex(t *testing.T) {
+	cases := []struct {
+		name  string
+		group *osmpbf.PrimitiveGroup
+	}{
+		{
+			name: "way tag key",
+			group: &osmpbf.PrimitiveGroup{Ways: []*osmpbf.Way{{
+				Id:   proto.Int64(1),
+				Keys: []uint32{outOfRangeIndex},
+				Vals: []uint32{outOfRangeIndex},
+			}}},
+		},
+		{
+			name: "relation member role",
+			group: &osmpbf.PrimitiveGroup{Relations: []*osmpbf.Relation{{
+				Id:       proto.Int64(1),
+				RolesSid: []int32{outOfRangeIndex},
+				Memids:   []int64{1},
+				Types:    []osmpbf.Relation_MemberType{osmpbf.Relation_NODE},
+			}}},
+		},
+		{
+			name: "dense node tag",
+			group: &osmpbf.PrimitiveGroup{Dense: &osmpbf.DenseNodes{
+				Id:       []int64{1},
+				Lat:      []int64{0},
+				Lon:      []int64{0},
+				KeysVals: []int32{outOfRangeIndex, outOfRangeIndex, 0},
+			}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data := pbfWithGroup(t, tc.group)
+
+			scanner := New(context.Background(), bytes.NewReader(data), 1)
+			defer scanner.Close()
+
+			for scanner.Scan() {
+			}
+
+			err := scanner.Err()
+			if err == nil {
+				t.Fatal("expected an error for the out-of-range string table index, got nil")
+			}
+			if !strings.Contains(err.Error(), "string table index") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What

`osmpbf` panics with `runtime error: index out of range` when a `.osm.pbf`
file contains a string table index that points past the end of the block's
string table.

In a `PrimitiveBlock` the key, value, role and user fields of ways, relations
and dense nodes are all indexes into the block's string table. The decoder
looked them up directly (`st[k]`, `stringTable[v]`, `st[r]`, `st[usid]`, …)
without checking the value first — the code even notes the assumption:

```go
// note we assume keys and vals are the same length
// we also assume index are within range of the stringTable
```

A file where that assumption doesn't hold makes the decoder panic instead of
returning an error. Decoding happens on background goroutines, so the panic
isn't something a caller can recover from — it takes down the whole process.
Any program that scans untrusted PBF input can be crashed with a small
malformed file.

### Reproduce

With a crafted block whose string table has one entry but whose way references
key index 5:

```
panic: runtime error: index out of range [5] with length 1

goroutine 12 [running]:
github.com/paulmach/osm/osmpbf.scanTags(...)
	.../osmpbf/decode_data.go:851
github.com/paulmach/osm/osmpbf.(*dataDecoder).scanWays(...)
	.../osmpbf/decode_data.go:660
github.com/paulmach/osm/osmpbf.(*dataDecoder).scanPrimitiveGroup(...)
...
```

The added test `TestOutOfRangeStringTableIndex` builds minimal PBF streams that
trigger this via way tags, relation member roles and dense-node tags. It panics
on `master` and passes with this change.

### Fix

Add a small helper that validates the index and returns an error for an
out-of-range one, and route every string table lookup through it. Well-formed
files are unaffected; the existing `osmpbf` tests (including the real `.pbf`
fixtures) still pass, as does `go test -race ./osmpbf/`.
